### PR TITLE
fix: prevent error when file doesn't exist

### DIFF
--- a/cryo_utilities.sh
+++ b/cryo_utilities.sh
@@ -85,7 +85,7 @@ if zenity --question --title="Disclaimer" --text="This script was made by CryoBy
         echo "-------------------"
         sudo sysctl -w "vm.swappiness=$SWAPPINESS_ANSWER"
         if [ "$SWAPPINESS_ANSWER" -eq "100" ]; then
-            sudo rm /etc/sysctl.d/zzz-custom-swappiness.conf
+            sudo rm -f /etc/sysctl.d/zzz-custom-swappiness.conf
         else
             echo "vm.swappiness=$SWAPPINESS_ANSWER" | sudo tee /etc/sysctl.d/zzz-custom-swappiness.conf
         fi


### PR DESCRIPTION
The first time I ran this, I accidentally kept `vm.swappiness = 100` and noticed an error in the logs:

```
rm: cannot remove '/etc/sysctl.d/zzz-custom-swappiness.conf': No such file or directory
```

This should fix that.