### PR TITLE
fix: button and windows resizing did not work on external display

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -1,5 +1,5 @@
 !/bin/bash
-if [ "$(xrandr --current --verbose | grep '*' | xargs | cut -d ' ' -f1)" = "800x1280" ]; then
+if [ "$(xrandr --current | grep '*' | xargs | cut -d ' ' -f1)" = "800x1280" ]; then
   export FYNE_SCALE=0.25
 fi
 

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-if [ "$(xdpyinfo | grep dimension | awk '{print $2}' | cut -d 'x' -f2)" -eq "800" ]; then
-  export FYNE_SCALE=0.25
-fi
+export FYNE_SCALE=0.25
 
 "$HOME"/.cryo_utilities/cryo_utilities gui

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
-export FYNE_SCALE=0.25
+!/bin/bash
+if [ "$(xrandr --current --verbose | grep '*' | xargs | cut -d ' ' -f1)" = "800x1280" ]; then
+  export FYNE_SCALE=0.25
+fi
 
 "$HOME"/.cryo_utilities/cryo_utilities gui


### PR DESCRIPTION
I had a weird issue on external display:

![1](https://user-images.githubusercontent.com/1198771/220013231-9f7916ed-b8ab-47df-bfa4-cd81fac85408.png)

It works well on the steamdeck though. I am not sure why you added that check.  If you really need it, may I suggest to use:

```
if [ "$(xdpyinfo | grep dimension | awk '{print $2}' | cut -d 'x' -f2)" -le "1280" ]; then
  export FYNE_SCALE=0.25
fi
```
