### PR TITLE
Small fixes

### DIFF
--- a/cmd/cryoutilities/main.go
+++ b/cmd/cryoutilities/main.go
@@ -4,27 +4,23 @@ import (
 	"context"
 	"cryoutilities/internal"
 	"errors"
-	"github.com/cristalhq/acmd"
 	"log"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/cristalhq/acmd"
 )
 
 func main() {
 	// Delete old log file
-	_ = os.Remove(internal.LogFilePath)
+	os.Remove(internal.LogFilePath)
 	// Create a log file
 	logFile, err := os.OpenFile(internal.LogFilePath, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		log.Panic(err)
 	}
-	defer func(logFile *os.File) {
-		err := logFile.Close()
-		if err != nil {
-
-		}
-	}(logFile)
+	defer logFile.Close()
 	log.SetOutput(logFile)
 
 	// Create loggers
@@ -39,7 +35,7 @@ func main() {
 		{
 			Name:        "gui",
 			Description: "Run in GUI mode",
-			ExecFunc: func(ctx context.Context, args []string) error {
+			ExecFunc: func(context.Context, []string) error {
 				internal.InitUI()
 				return nil
 			},
@@ -47,7 +43,7 @@ func main() {
 		{
 			Name:        "swap",
 			Description: "Change swap file size in increments of 1GB.",
-			ExecFunc: func(ctx context.Context, args []string) error {
+			ExecFunc: func(_ context.Context, args []string) error {
 				internal.CryoUtils.InfoLog.Println("Starting swap file resize...")
 				size, err := strconv.Atoi(args[0])
 				if err != nil {
@@ -64,7 +60,7 @@ func main() {
 		{
 			Name:        "swappiness",
 			Description: "Change swappiness to the specified value 0-200.",
-			ExecFunc: func(ctx context.Context, args []string) error {
+			ExecFunc: func(_ context.Context, args []string) error {
 				internal.CryoUtils.InfoLog.Println("Starting swappiness change...")
 				swappiness := args[0]
 				swappinessInt, err := strconv.Atoi(swappiness)
@@ -82,7 +78,7 @@ func main() {
 		{
 			Name:        "hugepages",
 			Description: "Enable or disable hugepages. Accepts 'true', 'false', 'enable' or 'disable'.\n\tRecommended: Enabled",
-			ExecFunc: func(ctx context.Context, args []string) error {
+			ExecFunc: func(_ context.Context, args []string) error {
 				arg := strings.ToLower(args[0])
 				if arg == "true" || arg == "enable" {
 					internal.CryoUtils.InfoLog.Println("Enabling HugePages...")
@@ -105,7 +101,7 @@ func main() {
 		{
 			Name:        "compaction_proactiveness",
 			Description: "Set or revert compaction proactiveness. Accepts 'recommended' or 'stock'.",
-			ExecFunc: func(ctx context.Context, args []string) error {
+			ExecFunc: func(_ context.Context, args []string) error {
 				arg := strings.ToLower(args[0])
 				if arg == "recommended" {
 					internal.CryoUtils.InfoLog.Println("Setting Compaction Proactiveness...")
@@ -128,7 +124,7 @@ func main() {
 		{
 			Name:        "defrag",
 			Description: "Enable or disable hugepage defrag. Accepts 'true', 'false', 'enable' or 'disable'.\n\tRecommended: Disabled",
-			ExecFunc: func(ctx context.Context, args []string) error {
+			ExecFunc: func(_ context.Context, args []string) error {
 				arg := strings.ToLower(args[0])
 				if arg == "true" || arg == "enable" {
 					internal.CryoUtils.InfoLog.Println("Enabling HugePAge Defrag...")
@@ -151,7 +147,7 @@ func main() {
 		{
 			Name:        "page_lock_unfairness",
 			Description: "Set or revert page lock unfairness. Accepts 'recommended' or 'stock'.",
-			ExecFunc: func(ctx context.Context, args []string) error {
+			ExecFunc: func(_ context.Context, args []string) error {
 				arg := strings.ToLower(args[0])
 				if arg == "recommended" {
 					internal.CryoUtils.InfoLog.Println("Setting Page Lock Unfairness...")
@@ -174,7 +170,7 @@ func main() {
 		{
 			Name:        "shmem",
 			Description: "Enable or disable shared memory. Accepts 'true', 'false', 'enable' or 'disable'.\n\tRecommended: Enabled",
-			ExecFunc: func(ctx context.Context, args []string) error {
+			ExecFunc: func(_ context.Context, args []string) error {
 				arg := strings.ToLower(args[0])
 				if arg == "true" || arg == "enable" {
 					internal.CryoUtils.InfoLog.Println("Setting Shared Memory...")
@@ -197,7 +193,7 @@ func main() {
 		{
 			Name:        "recommended",
 			Description: "Set all values to Cryo's recommendations.",
-			ExecFunc: func(ctx context.Context, args []string) error {
+			ExecFunc: func(context.Context, []string) error {
 				err := internal.UseRecommendedSettings()
 				if err != nil {
 					return err
@@ -208,7 +204,7 @@ func main() {
 		{
 			Name:        "stock",
 			Description: "Set all values to Valve defaults.",
-			ExecFunc: func(ctx context.Context, args []string) error {
+			ExecFunc: func(context.Context, []string) error {
 				err := internal.UseStockSettings()
 				if err != nil {
 					return err

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module cryoutilities
 
-go 1.19
+go 1.20
 
 require (
 	fyne.io/fyne/v2 v2.3.1-rc2

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,8 +1,8 @@
 package internal
 
 import (
-	"fmt"
 	"image/color"
+	"path/filepath"
 )
 
 // CurrentVersionNumber Version number to build with, Fyne can't support build flags just yet.
@@ -12,7 +12,7 @@ var CurrentVersionNumber = "2.0.0"
 var InstallDirectory = "/home/deck/.cryo_utilities"
 
 // LogFilePath Location of the log file
-var LogFilePath = fmt.Sprintf("%s/cryoutilities.log", InstallDirectory)
+var LogFilePath = filepath.Join(InstallDirectory, "cryoutilities.log")
 
 //////////////////////////
 // Recommended Settings //
@@ -118,19 +118,19 @@ var MountDirectory = "/run/media"
 var SteamDataRoot = "/home/deck/.local/share/Steam"
 
 // SteamCompatRoot Generates the full path of the compatdata folder, on SSD
-var SteamCompatRoot = fmt.Sprintf("%s/steamapps/compatdata", SteamDataRoot)
+var SteamCompatRoot = filepath.Join(SteamDataRoot, "steamapps/compatdata")
 
 // SteamShaderRoot Generates the full path of the shadercache folder, on SSD
-var SteamShaderRoot = fmt.Sprintf("%s/steamapps/shadercache", SteamDataRoot)
+var SteamShaderRoot = filepath.Join(SteamDataRoot, "steamapps/shadercache")
 
 // ExternalDataRoot The location where I'll keep compatdata and shadercache on microSD cards
 var ExternalDataRoot = "cryoutilities_steam_data"
 
 // ExternalCompatRoot Generates the full path of the compatdata folder, on microSD
-var ExternalCompatRoot = fmt.Sprintf("%s/compatdata", ExternalDataRoot)
+var ExternalCompatRoot = filepath.Join(ExternalDataRoot, "compatdata")
 
 // ExternalShaderRoot Generates the full path of the shadercache folder, on microSD
-var ExternalShaderRoot = fmt.Sprintf("%s/shadercache", ExternalDataRoot)
+var ExternalShaderRoot = filepath.Join(ExternalDataRoot, "shadercache")
 
 // SteamApiUrl The URL for the Steam GetAppList URL
 var SteamApiUrl = "https://api.steampowered.com/ISteamApps/GetAppList/v0002/"

--- a/internal/handler_cli.go
+++ b/internal/handler_cli.go
@@ -51,7 +51,8 @@ func UseRecommendedSettings() error {
 	}
 	if availableSpace < RecommendedSwapSizeBytes {
 		size := 1
-		availableSizes, err := getAvailableSwapSizes()
+		var availableSizes []string
+		availableSizes, err = getAvailableSwapSizes()
 		if err != nil {
 			return err
 		}

--- a/internal/handler_game_data.go
+++ b/internal/handler_game_data.go
@@ -2,9 +2,11 @@ package internal
 
 import (
 	"fmt"
-	cp "github.com/otiai10/copy"
 	"os"
+	"path/filepath"
 	"strconv"
+
+	cp "github.com/otiai10/copy"
 )
 
 type StorageStatus struct {
@@ -57,8 +59,8 @@ func (s *StorageStatus) getStorageStatus(left string, right string) error {
 			return err
 		}
 	} else {
-		compat := fmt.Sprintf("%s/%s", left, ExternalCompatRoot)
-		shader := fmt.Sprintf("%s/%s", left, ExternalShaderRoot)
+		compat := filepath.Join(left, ExternalCompatRoot)
+		shader := filepath.Join(left, ExternalShaderRoot)
 		// Create the directories if they don't exist already
 		_ = os.MkdirAll(compat, 0777)
 		_ = os.MkdirAll(shader, 0777)
@@ -82,8 +84,8 @@ func (s *StorageStatus) getStorageStatus(left string, right string) error {
 			return err
 		}
 	} else {
-		compat := fmt.Sprintf("%s/%s", right, ExternalCompatRoot)
-		shader := fmt.Sprintf("%s/%s", right, ExternalShaderRoot)
+		compat := filepath.Join(right, ExternalCompatRoot)
+		shader := filepath.Join(right, ExternalShaderRoot)
 		// Create the directories if they don't exist already
 		_ = os.MkdirAll(compat, 0777)
 		_ = os.MkdirAll(shader, 0777)
@@ -105,26 +107,26 @@ func (d *DataToMove) getSpaceNeeded(left string, right string) {
 		leftCompat = SteamCompatRoot
 		leftShader = SteamShaderRoot
 	} else {
-		leftCompat = fmt.Sprintf("%s/%s", left, ExternalCompatRoot)
-		leftShader = fmt.Sprintf("%s/%s", left, ExternalShaderRoot)
+		leftCompat = filepath.Join(left, ExternalCompatRoot)
+		leftShader = filepath.Join(left, ExternalShaderRoot)
 	}
 
 	if right == SteamDataRoot {
 		rightCompat = SteamCompatRoot
 		rightShader = SteamShaderRoot
 	} else {
-		rightCompat = fmt.Sprintf("%s/%s", right, ExternalCompatRoot)
-		rightShader = fmt.Sprintf("%s/%s", right, ExternalShaderRoot)
+		rightCompat = filepath.Join(right, ExternalCompatRoot)
+		rightShader = filepath.Join(right, ExternalShaderRoot)
 	}
 
 	for x := range d.left {
-		d.leftSize += getDirectorySize(fmt.Sprintf("%s/%s", leftCompat, d.left[x]))
-		d.leftSize += getDirectorySize(fmt.Sprintf("%s/%s", leftShader, d.left[x]))
+		d.leftSize += getDirectorySize(filepath.Join(leftCompat, d.left[x]))
+		d.leftSize += getDirectorySize(filepath.Join(leftShader, d.left[x]))
 	}
 
 	for x := range d.right {
-		d.rightSize += getDirectorySize(fmt.Sprintf("%s/%s", rightCompat, d.right[x]))
-		d.rightSize += getDirectorySize(fmt.Sprintf("%s/%s", rightShader, d.right[x]))
+		d.rightSize += getDirectorySize(filepath.Join(rightCompat, d.right[x]))
+		d.rightSize += getDirectorySize(filepath.Join(rightShader, d.right[x]))
 	}
 }
 
@@ -179,31 +181,31 @@ func moveGameData(data DataToMove, left string, right string) error {
 		leftCompatPath = SteamCompatRoot
 		leftShaderPath = SteamShaderRoot
 	} else {
-		leftCompatPath = fmt.Sprintf("%s/%s", left, ExternalCompatRoot)
-		leftShaderPath = fmt.Sprintf("%s/%s", left, ExternalShaderRoot)
+		leftCompatPath = filepath.Join(left, ExternalCompatRoot)
+		leftShaderPath = filepath.Join(left, ExternalShaderRoot)
 	}
 
 	if right == SteamDataRoot {
 		rightCompatPath = SteamCompatRoot
 		rightShaderPath = SteamShaderRoot
 	} else {
-		rightCompatPath = fmt.Sprintf("%s/%s", right, ExternalCompatRoot)
-		rightShaderPath = fmt.Sprintf("%s/%s", right, ExternalShaderRoot)
+		rightCompatPath = filepath.Join(right, ExternalCompatRoot)
+		rightShaderPath = filepath.Join(right, ExternalShaderRoot)
 	}
 
 	// Moving to the left
 	for _, directory := range data.right {
-		leftCompatDir := fmt.Sprintf("%s/%s", leftCompatPath, directory)
-		leftShaderDir := fmt.Sprintf("%s/%s", leftShaderPath, directory)
-		rightCompatDir := fmt.Sprintf("%s/%s", rightCompatPath, directory)
-		rightShaderDir := fmt.Sprintf("%s/%s", rightShaderPath, directory)
+		leftCompatDir := filepath.Join(leftCompatPath, directory)
+		leftShaderDir := filepath.Join(leftShaderPath, directory)
+		rightCompatDir := filepath.Join(rightCompatPath, directory)
+		rightShaderDir := filepath.Join(rightShaderPath, directory)
 
 		// Remove any symlinks on the SSD in preparation for either moving to the SSD, or creating new symlinks
-		steamCompatDir := fmt.Sprintf("%s/%s", SteamCompatRoot, directory)
+		steamCompatDir := filepath.Join(SteamCompatRoot, directory)
 		if isSymbolicLink(steamCompatDir) {
 			_ = os.Remove(steamCompatDir)
 		}
-		steamShaderDir := fmt.Sprintf("%s/%s", SteamShaderRoot, directory)
+		steamShaderDir := filepath.Join(SteamShaderRoot, directory)
 		if isSymbolicLink(steamShaderDir) {
 			_ = os.Remove(steamShaderDir)
 		}
@@ -241,12 +243,12 @@ func moveGameData(data DataToMove, left string, right string) error {
 		if leftCompatPath != SteamCompatRoot {
 			// Create symlinks on the SSD to the new location
 			CryoUtils.InfoLog.Println("Creating symlink to new path on SSD...")
-			err = os.Symlink(leftCompatDir, fmt.Sprintf("%s/%s", SteamCompatRoot, directory))
+			err = os.Symlink(leftCompatDir, filepath.Join(SteamCompatRoot, directory))
 			if err != nil {
 				CryoUtils.ErrorLog.Println(err)
 				return err
 			}
-			err = os.Symlink(leftShaderDir, fmt.Sprintf("%s/%s", SteamShaderRoot, directory))
+			err = os.Symlink(leftShaderDir, filepath.Join(SteamShaderRoot, directory))
 			if err != nil {
 				CryoUtils.ErrorLog.Println(err)
 				return err
@@ -258,17 +260,17 @@ func moveGameData(data DataToMove, left string, right string) error {
 
 	// Moving to the right
 	for _, directory := range data.left {
-		leftCompatDir := fmt.Sprintf("%s/%s", leftCompatPath, directory)
-		leftShaderDir := fmt.Sprintf("%s/%s", leftShaderPath, directory)
-		rightCompatDir := fmt.Sprintf("%s/%s", rightCompatPath, directory)
-		rightShaderDir := fmt.Sprintf("%s/%s", rightShaderPath, directory)
+		leftCompatDir := filepath.Join(leftCompatPath, directory)
+		leftShaderDir := filepath.Join(leftShaderPath, directory)
+		rightCompatDir := filepath.Join(rightCompatPath, directory)
+		rightShaderDir := filepath.Join(rightShaderPath, directory)
 
 		// Remove any symlinks on the SSD in preparation for either moving to the SSD, or creating new symlinks
-		steamCompatDir := fmt.Sprintf("%s/%s", SteamCompatRoot, directory)
+		steamCompatDir := filepath.Join(SteamCompatRoot, directory)
 		if isSymbolicLink(steamCompatDir) {
 			_ = os.Remove(steamCompatDir)
 		}
-		steamShaderDir := fmt.Sprintf("%s/%s", SteamShaderRoot, directory)
+		steamShaderDir := filepath.Join(SteamShaderRoot, directory)
 		if isSymbolicLink(steamShaderDir) {
 			_ = os.Remove(steamShaderDir)
 		}
@@ -306,12 +308,12 @@ func moveGameData(data DataToMove, left string, right string) error {
 		if rightCompatPath != SteamCompatRoot {
 			// Create symlinks on the SSD to the new location
 			CryoUtils.InfoLog.Println("Creating symlink to new path on SSD...")
-			err = os.Symlink(rightCompatDir, fmt.Sprintf("%s/%s", SteamCompatRoot, directory))
+			err = os.Symlink(rightCompatDir, filepath.Join(SteamCompatRoot, directory))
 			if err != nil {
 				CryoUtils.ErrorLog.Println(err)
 				return err
 			}
-			err = os.Symlink(rightShaderDir, fmt.Sprintf("%s/%s", SteamShaderRoot, directory))
+			err = os.Symlink(rightShaderDir, filepath.Join(SteamShaderRoot, directory))
 			if err != nil {
 				CryoUtils.ErrorLog.Println(err)
 				return err

--- a/internal/handler_library.go
+++ b/internal/handler_library.go
@@ -1,15 +1,16 @@
 package internal
 
 import (
-	"github.com/andygrunwald/vdf"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/andygrunwald/vdf"
 )
 
 type Library struct {
-	InstalledGames []int
 	Path           string
+	InstalledGames []int
 }
 
 func (lib *Library) listGames() {

--- a/internal/handler_steam_api.go
+++ b/internal/handler_steam_api.go
@@ -10,8 +10,8 @@ import (
 type AppResponse struct {
 	Applist struct {
 		Apps []struct {
-			Appid int    `json:"appid"`
 			Name  string `json:"name"`
+			Appid int    `json:"appid"`
 		} `json:"apps"`
 	} `json:"applist"`
 }
@@ -36,12 +36,7 @@ func querySteamAPI() (AppResponse, error) {
 	}
 
 	if res.Body != nil {
-		defer func(Body io.ReadCloser) {
-			err := Body.Close()
-			if err != nil {
-
-			}
-		}(res.Body)
+		defer res.Body.Close()
 	}
 
 	body, err := io.ReadAll(res.Body)

--- a/internal/ui_authentication.go
+++ b/internal/ui_authentication.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"os/exec"
+	"time"
 
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/widget"
@@ -44,6 +45,8 @@ func testAuth(password string) error {
 	defer d.Hide()
 	// Do a really basic command to renew sudo auth
 	cmd := exec.Command("sudo", "-S", "--", "echo")
+	//Sudo will exit immediately if it's the correct password, but will hang for a moment if it isn't.
+	cmd.WaitDelay = 500 * time.Millisecond
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return err
@@ -57,6 +60,7 @@ func testAuth(password string) error {
 		cmd.Process.Kill()
 		return err
 	}
+	stdin.Close()
 	err = cmd.Wait()
 	if err != nil {
 		return err

--- a/internal/ui_authentication.go
+++ b/internal/ui_authentication.go
@@ -12,6 +12,8 @@ import (
 func renewSudoAuth() {
 	// Do a really basic command to renew sudo auth
 	cmd := exec.Command("sudo", "-S", "--", "echo")
+	//Sudo will exit immediately if it's the correct password, but will hang for a moment if it isn't.
+	cmd.WaitDelay = 500 * time.Millisecond
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		CryoUtils.ErrorLog.Println(err)
@@ -28,6 +30,7 @@ func renewSudoAuth() {
 		CryoUtils.ErrorLog.Println(err)
 		return
 	}
+	stdin.Close()
 	err = cmd.Wait()
 	if err != nil {
 		CryoUtils.ErrorLog.Println(err)

--- a/internal/ui_util.go
+++ b/internal/ui_util.go
@@ -2,11 +2,13 @@ package internal
 
 import (
 	"fmt"
+	"path/filepath"
+	"sort"
+	"strconv"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/widget"
-	"sort"
-	"strconv"
 )
 
 type GameStatus struct {
@@ -51,8 +53,8 @@ func createGameDataList() (*widget.CheckGroup, error) {
 			compat = SteamCompatRoot
 			shader = SteamShaderRoot
 		} else {
-			compat = fmt.Sprintf("%s/%s", libraries[i].Path, ExternalCompatRoot)
-			shader = fmt.Sprintf("%s/%s", libraries[i].Path, ExternalShaderRoot)
+			compat = filepath.Join(libraries[i].Path, ExternalCompatRoot)
+			shader = filepath.Join(libraries[i].Path, ExternalShaderRoot)
 		}
 
 		// Crawl the compat path and append the folders
@@ -181,7 +183,7 @@ func (app *Config) refreshSwapContent() {
 	swap, err := getSwapFileSize()
 	if err != nil {
 		CryoUtils.ErrorLog.Println(err)
-		swapStr := fmt.Sprintf("Current Swap Size: Unknown")
+		swapStr := "Current Swap Size: Unknown"
 		app.SwapText.Text = swapStr
 		app.SwapText.Color = Gray
 	} else {
@@ -203,7 +205,7 @@ func (app *Config) refreshSwappinessContent() {
 	swappiness, err := getSwappinessValue()
 	if err != nil {
 		CryoUtils.ErrorLog.Println(err)
-		swappinessStr := fmt.Sprintf("Current Swappiness: Unknown")
+		swappinessStr := "Current Swappiness: Unknown"
 		app.SwappinessText.Text = swappinessStr
 		app.SwappinessText.Color = Gray
 	} else {

--- a/internal/ui_window.go
+++ b/internal/ui_window.go
@@ -2,14 +2,16 @@ package internal
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/widget"
-	"os"
-	"strconv"
-	"strings"
 )
 
 func syncGameDataWindow() {
@@ -259,7 +261,7 @@ func cleanupDataWindow() {
 					CryoUtils.InfoLog.Println("Removing the following content:")
 					for i := range removeList {
 						for j := range possibleLocations {
-							path := fmt.Sprintf("%s/%s", possibleLocations[j], removeList[i])
+							path := filepath.Join(possibleLocations[j], removeList[i])
 							CryoUtils.InfoLog.Println(path)
 							err = os.RemoveAll(path)
 							if err != nil {

--- a/internal/util.go
+++ b/internal/util.go
@@ -138,7 +138,7 @@ func isSubPath(parent string, sub string) bool {
 func writeFile(path string, contents string) error {
 	CryoUtils.InfoLog.Println("Writing", path)
 
-	tempPath := fmt.Sprintf("%s/temp.txt", InstallDirectory)
+	tempPath := filepath.Join(InstallDirectory, "temp.txt")
 	// Try to remove tempfile just in case it exists for some reason
 	_ = removeFile(tempPath)
 	// Write to the CU install directory to avoid permissions issues
@@ -246,7 +246,7 @@ func getUnitStatus(param string) (string, error) {
 }
 
 func writeUnitFile(param string, value string) error {
-	path := fmt.Sprintf("%s/%s.conf", TmpFilesRoot, param)
+	path := filepath.Join(TmpFilesRoot, param+".conf")
 	CryoUtils.InfoLog.Println("Writing", value, "to", path, "to preserve", param, "setting...")
 	contents := strings.ReplaceAll(TemplateUnitFile, "PARAM", UnitMatrix[param])
 	contents = strings.ReplaceAll(contents, "VALUE", value)
@@ -259,7 +259,7 @@ func writeUnitFile(param string, value string) error {
 }
 
 func removeUnitFile(param string) error {
-	path := fmt.Sprintf("%s/%s.conf", TmpFilesRoot, param)
+	path := filepath.Join(TmpFilesRoot, param+".conf")
 	CryoUtils.InfoLog.Println("Removing", path, "to revert", param, "setting...")
 	err := removeFile(path)
 	if err != nil {

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 if [ "$(xrandr --current | grep '*' | xargs | cut -d ' ' -f1)" = "800x1280" ]; then
   export FYNE_SCALE=0.25
 fi


### PR DESCRIPTION
Your Youtube video pop-up for me and I decided to take a look since I have a decent amount of experience with Go.

- Small changes suggested by the linter. Mostly just field alignment and unused variables
- Replaced instances of `fmt.Sprintf` to join filepaths to `filepath.Join`
- Removed several instances of deferred functions that's purpose was to catch a `.Close()` error. Very few libraries actually make use of `io.Closer`'s error return and it's usually safe to ignore it.
  - As an example an `*os.File`'s `.Close()` will only ever return an error if it's already been closed.
- Reworked how sending input to commands for sudo authentication worked.
  - Instead of using a goroutine, it's better to start the command, send the input, and wait for the command to exit on it's own. I also just added a `\n` instead of manually closing the stdin pipe.

