### PR TITLE
feat: add GPU tab to display VRAM info

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -26,6 +26,7 @@ var RecommendedCompactionProactiveness = "0"
 var RecommendedHugePageDefrag = "0"
 var RecommendedPageLockUnfairness = "1"
 var RecommendedShMem = "advise"
+var RecommendedVRAM = 4096
 
 //////////////////////
 // Default Settings //

--- a/internal/handler_gpu.go
+++ b/internal/handler_gpu.go
@@ -1,0 +1,28 @@
+package internal
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Get the current VRAM
+func getVRAMValue() (int, error) {
+	cmd, err := exec.Command("glxinfo", "-B").Output()
+
+	// Extract video memory
+	re := regexp.MustCompile(`Video memory: [0-9]+`)
+	match := re.FindStringSubmatch(string(cmd))
+
+	if err != nil || match == nil {
+		return 100, fmt.Errorf("error getting current VRAM")
+	}
+
+	output := strings.Split(match[0], " ")[2]
+	CryoUtils.InfoLog.Println("Found a VRAM of", output)
+	vram, _ := strconv.Atoi(output)
+
+	return vram, nil
+}

--- a/internal/ui_base.go
+++ b/internal/ui_base.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"errors"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/app"
 	"fyne.io/fyne/v2/container"
@@ -56,6 +57,7 @@ func (app *Config) mainUI() {
 		container.NewTabItemWithIcon("Swap", theme.MailReplyAllIcon(), app.swapTab()),
 		container.NewTabItemWithIcon("Memory", theme.ComputerIcon(), app.memoryTab()),
 		container.NewTabItemWithIcon("Storage", theme.StorageIcon(), app.storageTab()),
+		container.NewTabItemWithIcon("GPU", theme.MediaVideoIcon(), app.gpuTab()),
 	)
 	tabs.SetTabLocation(container.TabLocationTop)
 

--- a/internal/ui_base.go
+++ b/internal/ui_base.go
@@ -57,7 +57,7 @@ func (app *Config) mainUI() {
 		container.NewTabItemWithIcon("Swap", theme.MailReplyAllIcon(), app.swapTab()),
 		container.NewTabItemWithIcon("Memory", theme.ComputerIcon(), app.memoryTab()),
 		container.NewTabItemWithIcon("Storage", theme.StorageIcon(), app.storageTab()),
-		container.NewTabItemWithIcon("GPU", theme.MediaVideoIcon(), app.gpuTab()),
+		container.NewTabItemWithIcon("VRAM", theme.MediaVideoIcon(), app.vramTab()),
 	)
 	tabs.SetTabLocation(container.TabLocationTop)
 

--- a/internal/ui_tab.go
+++ b/internal/ui_tab.go
@@ -264,12 +264,12 @@ func (app *Config) vramTab() *fyne.Container {
 
 	vramCard := widget.NewCard("Minimum VRAM", "How to change the minimum VRAM:", textVBox)
 
-	app.VRAMBar = container.NewGridWithColumns(1,
+	vramBAR := container.NewGridWithColumns(1,
 		container.NewCenter(app.VRAMText))
 	topBar := container.NewVBox(
 		container.NewGridWithRows(1),
 		container.NewGridWithRows(1, container.NewCenter(canvas.NewText("Current Tweak Status:", White))),
-		app.VRAMBar,
+		vramBAR,
 	)
 
 	vramVBOX := container.NewVBox(

--- a/internal/ui_tab.go
+++ b/internal/ui_tab.go
@@ -242,37 +242,40 @@ func (app *Config) memoryTab() *fyne.Container {
 	return full
 }
 
-// Get VRAM data
-func (app *Config) gpuTab() *fyne.Container {
+func (app *Config) vramTab() *fyne.Container {
 	app.VRAMText = canvas.NewText("Current VRAM size: Unknown", Gray)
 
 	// Get VRAM value
 	app.refreshVRAMContent()
 
-	CryoUtils.VRAMButton = widget.NewButton("Increase VRAM", func() {
-		dialog.ShowInformation(
-			"Increase your VRAM",
-			"To change that setting you need to turnoff your Steam Deck.\n"+
-				"Press and hold the Volume Up button and press the Power button.\n\n"+
-				"Setup Utility -> Advanced -> UMA Frame Buffer Size\n\n"+
-				"For most use case using 4GB is recommended.\n\n"+
-				"Please be aware that it might cause issue on a few games such as RDR2.",
-			app.MainWindow)
-	})
-	vramCard := widget.NewCard("Video RAM", "", app.VRAMButton)
+	textHowTo := widget.NewLabel("1. Turn off the Steam Deck\n\n" +
+			"2. Press and hold the volume up button, press the power button, then release both\n\n" +
+			"3. Navigate to Setup Utility -> Advanced -> UMA Frame Buffer Size")
+	
+	textRecommended := widget.NewLabelWithStyle("4G is the recommended setting for most situations", fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
+	textWarning := widget.NewLabel("Please be aware that some games (RDR2) may experience degraded performance.")
 
-	app.GPUBar = container.NewGridWithColumns(1,
+
+	textVBox := container.NewVBox(
+		textHowTo,
+		textRecommended,
+		textWarning,
+	)
+
+	vramCard := widget.NewCard("Minimum VRAM", "How to change the minimum VRAM:", textVBox)
+
+	app.VRAMBar = container.NewGridWithColumns(1,
 		container.NewCenter(app.VRAMText))
 	topBar := container.NewVBox(
 		container.NewGridWithRows(1),
 		container.NewGridWithRows(1, container.NewCenter(canvas.NewText("Current Tweak Status:", White))),
-		app.GPUBar,
+		app.VRAMBar,
 	)
 
-	gpuVBox := container.NewVBox(
+	vramVBOX := container.NewVBox(
 		vramCard,
 	)
-	scroll := container.NewScroll(gpuVBox)
+	scroll := container.NewScroll(vramVBOX)
 	full := container.NewBorder(topBar, nil, nil, nil, scroll)
 
 	return full

--- a/internal/ui_tab.go
+++ b/internal/ui_tab.go
@@ -241,3 +241,39 @@ func (app *Config) memoryTab() *fyne.Container {
 
 	return full
 }
+
+// Get VRAM data
+func (app *Config) gpuTab() *fyne.Container {
+	app.VRAMText = canvas.NewText("Current VRAM size: Unknown", Gray)
+
+	// Get VRAM value
+	app.refreshVRAMContent()
+
+	CryoUtils.VRAMButton = widget.NewButton("Increase VRAM", func() {
+		dialog.ShowInformation(
+			"Increase your VRAM",
+			"To change that setting you need to turnoff your Steam Deck.\n"+
+				"Press and hold the Volume Up button and press the Power button.\n\n"+
+				"Setup Utility -> Advanced -> UMA Frame Buffer Size\n\n"+
+				"For most use case using 4GB is recommended.\n\n"+
+				"Please be aware that it might cause issue on a few games such as RDR2.",
+			app.MainWindow)
+	})
+	vramCard := widget.NewCard("Video RAM", "", app.VRAMButton)
+
+	app.GPUBar = container.NewGridWithColumns(1,
+		container.NewCenter(app.VRAMText))
+	topBar := container.NewVBox(
+		container.NewGridWithRows(1),
+		container.NewGridWithRows(1, container.NewCenter(canvas.NewText("Current Tweak Status:", White))),
+		app.GPUBar,
+	)
+
+	gpuVBox := container.NewVBox(
+		vramCard,
+	)
+	scroll := container.NewScroll(gpuVBox)
+	full := container.NewBorder(topBar, nil, nil, nil, scroll)
+
+	return full
+}

--- a/internal/ui_util.go
+++ b/internal/ui_util.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
-
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/widget"
@@ -296,7 +295,8 @@ func (app *Config) refreshVRAMContent() {
 		app.VRAMText.Text = vramStr
 		app.VRAMText.Color = Gray
 	} else {
-		vramStr := fmt.Sprintf("Current VRAM: %d", vram)
+		humanVRAMSize :=  getHumanVRAMSize(vram)
+		vramStr := fmt.Sprintf("Current VRAM: %s", humanVRAMSize)
 		app.VRAMText.Text = vramStr
 		if vram == RecommendedVRAM {
 			app.VRAMText.Color = Green

--- a/internal/ui_util.go
+++ b/internal/ui_util.go
@@ -287,6 +287,27 @@ func (app *Config) refreshPageLockUnfairnessContent() {
 	app.PageLockUnfairnessText.Refresh()
 }
 
+func (app *Config) refreshVRAMContent() {
+	app.InfoLog.Println("Refreshing VRAM data...")
+	vram, err := getVRAMValue()
+	if err != nil || vram == 0 {
+		CryoUtils.ErrorLog.Println(err)
+		vramStr := fmt.Sprintf("Current VRAM: Unknown")
+		app.VRAMText.Text = vramStr
+		app.VRAMText.Color = Gray
+	} else {
+		vramStr := fmt.Sprintf("Current VRAM: %d", vram)
+		app.VRAMText.Text = vramStr
+		if vram == RecommendedVRAM {
+			app.VRAMText.Color = Green
+		} else {
+			app.VRAMText.Color = Red
+		}
+	}
+
+	app.VRAMText.Refresh()
+}
+
 func (app *Config) refreshAllContent() {
 	app.refreshSwapContent()
 	app.refreshSwappinessContent()
@@ -295,4 +316,5 @@ func (app *Config) refreshAllContent() {
 	app.refreshShMemContent()
 	app.refreshDefragContent()
 	app.refreshPageLockUnfairnessContent()
+	app.refreshVRAMContent()
 }

--- a/internal/util.go
+++ b/internal/util.go
@@ -40,7 +40,6 @@ type Config struct {
 	MemoryContainer               *fyne.Container
 	SwapBar                       *fyne.Container
 	MemoryBar                     *fyne.Container
-	VRAMBar                        *fyne.Container
 	HugePagesButton               *widget.Button
 	ShMemButton                   *widget.Button
 	CompactionProactivenessButton *widget.Button

--- a/internal/util.go
+++ b/internal/util.go
@@ -40,7 +40,7 @@ type Config struct {
 	MemoryContainer               *fyne.Container
 	SwapBar                       *fyne.Container
 	MemoryBar                     *fyne.Container
-	GPUBar                        *fyne.Container
+	VRAMBar                        *fyne.Container
 	HugePagesButton               *widget.Button
 	ShMemButton                   *widget.Button
 	CompactionProactivenessButton *widget.Button
@@ -292,4 +292,15 @@ func setUnitValue(param string, value string) error {
 	io.Copy(os.Stdout, &buf)
 
 	return nil
+}
+
+func getHumanVRAMSize(size int) string {
+	// Converts the VRAM size to human readable format.
+	// The size argument is in MB.
+	text := fmt.Sprintf("%dMB", size)
+	if(size >= 1024) {
+		text = fmt.Sprintf("%dGB", size / 1024)
+	}
+
+	return text
 }

--- a/internal/util.go
+++ b/internal/util.go
@@ -30,6 +30,7 @@ type Config struct {
 	CompactionProactivenessText   *canvas.Text
 	DefragText                    *canvas.Text
 	PageLockUnfairnessText        *canvas.Text
+	VRAMText                      *canvas.Text
 	SteamAPIResponse              map[int]string
 	MainWindow                    fyne.Window
 	SwapResizeProgressBar         *widget.ProgressBar
@@ -39,11 +40,13 @@ type Config struct {
 	MemoryContainer               *fyne.Container
 	SwapBar                       *fyne.Container
 	MemoryBar                     *fyne.Container
+	GPUBar                        *fyne.Container
 	HugePagesButton               *widget.Button
 	ShMemButton                   *widget.Button
 	CompactionProactivenessButton *widget.Button
 	DefragButton                  *widget.Button
 	PageLockUnfairnessButton      *widget.Button
+	VRAMButton                    *widget.Button
 	UserPassword                  string
 	SwapFileLocation              string
 }

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -1,0 +1,51 @@
+package internal
+
+import "testing"
+
+func TestGetHumanVRAMSize(t *testing.T) {
+	type args struct {
+		size int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test 1",
+			args: args{
+				size: 256,
+			},
+			want: "256MB",
+		},
+		{
+			name: "Test 2",
+			args: args{
+				size: 1024,
+			},
+			want: "1GB",
+		},
+		{
+			name: "Test 3",
+			args: args{
+				size: 2048,
+			},
+			want: "2GB",
+		},
+		{
+			name: "Test 4",
+			args: args{
+				size: 4096,
+			},
+			want: "4GB",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getHumanVRAMSize(tt.args.size); got != tt.want {
+				t.Errorf("getHumanVRAMSize() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hi,

I thought it will be nice to have a tab to display the VRAM and teach people how to change it. (native speaker might help to review my english)

I am not proficient in go and tried to adapt to your style. I did not see any Unit Tests but I could add some. (e.g.: for the regex parsing). 

![1](https://user-images.githubusercontent.com/1198771/220554423-1c7c6804-39e6-468c-95c8-0320e0092c08.png)
![2](https://user-images.githubusercontent.com/1198771/220554435-ff864e10-6cde-4e46-b67f-dd5247550aeb.png)
