### PR TITLE
Add a progress bar when updating the application.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ echo "#!/usr/bin/env xdg-open
 Name=Update CryoUtilities
 Exec=curl https://raw.githubusercontent.com/CryoByte33/steam-deck-utilities/main/install.sh | bash -s --
 Icon=bittorrent-sync
-Terminal=false
+Terminal=true
 Type=Application
 StartupNotify=false" >"$HOME"/Desktop/UpdateCryoUtilities.desktop
 chmod +x "$HOME"/Desktop/UpdateCryoUtilities.desktop
@@ -93,7 +93,7 @@ echo "#!/usr/bin/env xdg-open
 Name=CryoUtilities - Update
 Exec=curl https://raw.githubusercontent.com/CryoByte33/steam-deck-utilities/main/install.sh | bash -s --
 Icon=bittorrent-sync
-Terminal=false
+Terminal=true
 Type=Application
 Categories=Utility
 StartupNotify=false" >"$HOME"/.local/share/applications/UpdateCryoUtilities.desktop


### PR DESCRIPTION
Updating takes about 8 minutes on my internet connection, so having a progress bar would be really useful. I've found that changing the "terminal" property of the "update" desktop icons/entries to "true" solves the problem and brings up a progress bar. Now I know that my update is actually downloading.