### PR TITLE
Removing a call to win.Close() on error. 

### DIFF
--- a/internal/ui_util.go
+++ b/internal/ui_util.go
@@ -20,7 +20,6 @@ type GameStatus struct {
 func presentErrorInUI(err error, win fyne.Window) {
 	CryoUtils.ErrorLog.Println(err)
 	dialog.ShowError(err, CryoUtils.MainWindow)
-	win.Close()
 }
 
 // Create a CheckGroup of game data to allow for selection.


### PR DESCRIPTION
Issue: https://github.com/CryoByte33/steam-deck-utilities/issues/69

This issue would result in the main app window closing for any errors instead of displaying an error to the user. After this PR, we will display the error message to the user with an "OK" button for them to acknowledge the error.

![image](https://user-images.githubusercontent.com/7245174/221119188-3264f8a4-b5c2-4ca9-b983-e46e3abb7ee0.png)
