### PR TITLE
Fixing bug where user could get past the password screen with the incorrect password if they were in an auth window.

### DIFF
--- a/internal/ui_authentication.go
+++ b/internal/ui_authentication.go
@@ -47,7 +47,7 @@ func testAuth(password string) error {
 	d.Show()
 	defer d.Hide()
 	// Do a really basic command to renew sudo auth
-	cmd := exec.Command("sudo", "-S", "--", "echo")
+	cmd := exec.Command("sudo", "-S", "-k", "--", "echo")
 	//Sudo will exit immediately if it's the correct password, but will hang for a moment if it isn't.
 	cmd.WaitDelay = 500 * time.Millisecond
 	stdin, err := cmd.StdinPipe()


### PR DESCRIPTION
Issue: https://github.com/CryoByte33/steam-deck-utilities/issues/83

Testing Steps:

Authenticate on the command line or within the app via sudo.
Close the app and reopen the app, entering an incorrect password.
Validate that you get the "incorrect password" flow.
Enter the correct password and validate that you can enter the app. 