### PR TITLE
Refactor get, set, revert, toggle methods in memory handler

### DIFF
--- a/cmd/cryoutilities/main.go
+++ b/cmd/cryoutilities/main.go
@@ -82,13 +82,13 @@ func main() {
 				arg := strings.ToLower(args[0])
 				if arg == "true" || arg == "enable" {
 					internal.CryoUtils.InfoLog.Println("Enabling HugePages...")
-					err := internal.SetHugePages()
+					err := internal.EnableTweak("hugepages")
 					if err != nil {
 						return err
 					}
 				} else if arg == "false" || arg == "disable" {
 					internal.CryoUtils.InfoLog.Println("Disabling HugePages...")
-					err := internal.RevertHugePages()
+					err := internal.RevertTweak("hugepages")
 					if err != nil {
 						return err
 					}
@@ -105,13 +105,13 @@ func main() {
 				arg := strings.ToLower(args[0])
 				if arg == "recommended" {
 					internal.CryoUtils.InfoLog.Println("Setting Compaction Proactiveness...")
-					err := internal.SetCompactionProactiveness()
+					err := internal.EnableTweak("compaction_proactiveness")
 					if err != nil {
 						return err
 					}
 				} else if arg == "stock" {
 					internal.CryoUtils.InfoLog.Println("Reverting Compaction Proactiveness...")
-					err := internal.RevertCompactionProactiveness()
+					err := internal.RevertTweak("compaction_proactiveness")
 					if err != nil {
 						return err
 					}
@@ -128,13 +128,13 @@ func main() {
 				arg := strings.ToLower(args[0])
 				if arg == "true" || arg == "enable" {
 					internal.CryoUtils.InfoLog.Println("Enabling HugePAge Defrag...")
-					err := internal.RevertDefrag()
+					err := internal.RevertTweak("defrag")
 					if err != nil {
 						return err
 					}
 				} else if arg == "false" || arg == "disable" {
 					internal.CryoUtils.InfoLog.Println("Revert Compaction Proactiveness...")
-					err := internal.SetDefrag()
+					err := internal.EnableTweak("defrag")
 					if err != nil {
 						return err
 					}
@@ -151,13 +151,13 @@ func main() {
 				arg := strings.ToLower(args[0])
 				if arg == "recommended" {
 					internal.CryoUtils.InfoLog.Println("Setting Page Lock Unfairness...")
-					err := internal.SetPageLockUnfairness()
+					err := internal.EnableTweak("page_lock_unfairness")
 					if err != nil {
 						return err
 					}
 				} else if arg == "stock" {
 					internal.CryoUtils.InfoLog.Println("Reverting Page Lock Unfairness...")
-					err := internal.RevertPageLockUnfairness()
+					err := internal.RevertTweak("page_lock_unfairness")
 					if err != nil {
 						return err
 					}
@@ -174,13 +174,13 @@ func main() {
 				arg := strings.ToLower(args[0])
 				if arg == "true" || arg == "enable" {
 					internal.CryoUtils.InfoLog.Println("Setting Shared Memory...")
-					err := internal.SetShMem()
+					err := internal.EnableTweak("shmem")
 					if err != nil {
 						return err
 					}
 				} else if arg == "false" || arg == "disable" {
 					internal.CryoUtils.InfoLog.Println("Reverting Shared Memory...")
-					err := internal.RevertShMem()
+					err := internal.RevertTweak("shmem")
 					if err != nil {
 						return err
 					}

--- a/internal/config.go
+++ b/internal/config.go
@@ -14,48 +14,35 @@ var InstallDirectory = "/home/deck/.cryo_utilities"
 // LogFilePath Location of the log file
 var LogFilePath = filepath.Join(InstallDirectory, "cryoutilities.log")
 
-//////////////////////////
-// Recommended Settings //
-//////////////////////////
+type Tweak struct {
+	Location    string
+	Recommended string
+	Default     string
+}
 
+////////////////////
+// Tweak Settings //
+////////////////////
+
+var TweakList = map[string]Tweak{
+	"swappiness":               {Location: "/proc/sys/vm/swappiness", Recommended: "1", Default: "100"},
+	"page_lock_unfairness":     {Location: "/proc/sys/vm/page_lock_unfairness", Recommended: "1", Default: "5"},
+	"compaction_proactiveness": {Location: "/proc/sys/vm/compaction_proactiveness", Recommended: "0", Default: "20"},
+	"hugepages":                {Location: "/sys/kernel/mm/transparent_hugepage/enabled", Recommended: "always", Default: "madvise"},
+	"shmem_enabled":            {Location: "/sys/kernel/mm/transparent_hugepage/shmem_enabled", Recommended: "advise", Default: "never"},
+	"defrag":                   {Location: "/sys/kernel/mm/transparent_hugepage/khugepaged/defrag", Recommended: "0", Default: "1"},
+}
+
+// These are supposed to be integers, I can't store them as strings in the map above. idk what to do about these.
 var RecommendedSwapSize = 16
 var RecommendedSwapSizeBytes = int64(RecommendedSwapSize * GigabyteMultiplier)
-var RecommendedSwappiness = "1"
-var RecommendedHugePages = "always"
-var RecommendedCompactionProactiveness = "0"
-var RecommendedHugePageDefrag = "0"
-var RecommendedPageLockUnfairness = "1"
-var RecommendedShMem = "advise"
-
-//////////////////////
-// Default Settings //
-//////////////////////
 
 var DefaultSwapSize = 1
 var DefaultSwapSizeBytes = int64(DefaultSwapSize * GigabyteMultiplier)
-var DefaultSwappiness = "100"
-var DefaultHugePages = "madvise"
-var DefaultCompactionProactiveness = "20"
-var DefaultHugePageDefrag = "1"
-var DefaultPageLockUnfairness = "5"
-var DefaultShMem = "never"
-
-////////////////
-// Unit Files //
-////////////////
 
 var TmpFilesRoot = "/etc/tmpfiles.d"
 
 var TemplateUnitFile = "# Path Mode UID GID Age Argument\nw PARAM - - - - VALUE"
-
-var UnitMatrix = map[string]string{
-	"swappiness":               "/proc/sys/vm/swappiness",
-	"page_lock_unfairness":     "/proc/sys/vm/page_lock_unfairness",
-	"compaction_proactiveness": "/proc/sys/vm/compaction_proactiveness",
-	"hugepages":                "/sys/kernel/mm/transparent_hugepage/enabled",
-	"shmem_enabled":            "/sys/kernel/mm/transparent_hugepage/shmem_enabled",
-	"defrag":                   "/sys/kernel/mm/transparent_hugepage/khugepaged/defrag",
-}
 
 var OldSwappinessUnitFile = "/etc/sysctl.d/zzz-custom-swappiness.conf"
 var NHPTestingFile = "/proc/sys/vm/nr_hugepages"

--- a/internal/handler_cli.go
+++ b/internal/handler_cli.go
@@ -78,37 +78,37 @@ func UseRecommendedSettings() error {
 		}
 	}
 	CryoUtils.InfoLog.Println("Swap file resized, changing swappiness...")
-	err = ChangeSwappiness(RecommendedSwappiness)
+	err = ChangeSwappiness(TweakList["swappiness"].Recommended)
 	if err != nil {
 		return err
 	}
 
 	CryoUtils.InfoLog.Println("Swappiness changed, enabling HugePages...")
-	err = SetHugePages()
+	err = EnableTweak("hugepages")
 	if err != nil {
 		return err
 	}
 
 	CryoUtils.InfoLog.Println("HugePages enabled, setting compaction proactiveness...")
-	err = SetCompactionProactiveness()
+	err = EnableTweak("compaction_proactiveness")
 	if err != nil {
 		return err
 	}
 
 	CryoUtils.InfoLog.Println("Compaction proactiveness changed, disabling hugePage defragmentation...")
-	err = SetDefrag()
+	err = EnableTweak("hugepage_defrag")
 	if err != nil {
 		return err
 	}
 
 	CryoUtils.InfoLog.Println("HugePage defragmentation disabled, setting page lock unfairness...")
-	err = SetPageLockUnfairness()
+	err = EnableTweak("page_lock_unfairness")
 	if err != nil {
 		return err
 	}
 
 	CryoUtils.InfoLog.Println("Page lock unfairness changed, enabling Shared Memory...")
-	err = SetShMem()
+	err = EnableTweak("shmem_enabled")
 	if err != nil {
 		return err
 	}
@@ -127,38 +127,38 @@ func UseStockSettings() error {
 
 	CryoUtils.InfoLog.Println("Setting swappiness to 100...")
 	// Revert swappiness
-	err = ChangeSwappiness(DefaultSwappiness)
+	err = ChangeSwappiness(TweakList["swappiness"].Default)
 	if err != nil {
 		return err
 	}
 
 	CryoUtils.InfoLog.Println("Disabling HugePages...")
 	// Enable HugePages
-	err = RevertHugePages()
+	err = RevertTweak("hugepages")
 	if err != nil {
 		return err
 	}
 
 	CryoUtils.InfoLog.Println("Reverting compaction proactiveness...")
-	err = RevertCompactionProactiveness()
+	err = RevertTweak("compaction_proactiveness")
 	if err != nil {
 		return err
 	}
 
 	CryoUtils.InfoLog.Println("Enabling hugePage defragmentation...")
-	err = RevertDefrag()
+	err = RevertTweak("hugepage_defrag")
 	if err != nil {
 		return err
 	}
 
 	CryoUtils.InfoLog.Println("Reverting page lock unfairness...")
-	err = RevertPageLockUnfairness()
+	err = RevertTweak("page_lock_unfairness")
 	if err != nil {
 		return err
 	}
 
 	CryoUtils.InfoLog.Println("Disabling shared memory in hugepages...")
-	err = RevertShMem()
+	err = RevertTweak("shmem_enabled")
 	if err != nil {
 		CryoUtils.InfoLog.Println("All settings reverted to default!")
 	}

--- a/internal/handler_memory.go
+++ b/internal/handler_memory.go
@@ -1,273 +1,47 @@
 package internal
 
-func getHugePagesStatus() bool {
-	status, err := getUnitStatus("hugepages")
+func isTweakEnabled(unit string) bool {
+	status, err := getUnitStatus(unit)
 	if err != nil {
-		CryoUtils.ErrorLog.Println("Unable to get current hugepages value")
+		CryoUtils.ErrorLog.Println("Unable to get current", unit, "value")
 		return false
 	}
-	if status == RecommendedHugePages {
-		return true
-	}
-	return false
+	return status == TweakList[unit].Recommended
 }
 
-func getCompactionProactivenessStatus() bool {
-	status, err := getUnitStatus("compaction_proactiveness")
+func EnableTweak(unit string) error {
+	CryoUtils.InfoLog.Println("Enabling", unit, "...")
+	err := setUnitValue(unit, TweakList[unit].Recommended)
 	if err != nil {
-		CryoUtils.ErrorLog.Println("Unable to get current compaction_proactiveness")
-		return false
-	}
-	if status == RecommendedCompactionProactiveness {
-		return true
-	}
-	return false
-}
-
-func getPageLockUnfairnessStatus() bool {
-	status, err := getUnitStatus("page_lock_unfairness")
-	if err != nil {
-		CryoUtils.ErrorLog.Println("Unable to get current page_lock_unfairness")
-		return false
-	}
-	if status == RecommendedPageLockUnfairness {
-		return true
-	}
-	return false
-}
-
-func getShMemStatus() bool {
-	status, err := getUnitStatus("shmem_enabled")
-	if err != nil {
-		CryoUtils.ErrorLog.Println("Unable to get current shmem_enabled")
-		return false
-	}
-	if status == RecommendedShMem {
-		return true
-	}
-	return false
-}
-
-func getDefragStatus() bool {
-	status, err := getUnitStatus("defrag")
-	if err != nil {
-		CryoUtils.ErrorLog.Println("Unable to get current defrag")
-		return false
-	}
-	if status == RecommendedHugePageDefrag {
-		return true
-	}
-	return false
-}
-
-// ToggleHugePages Simple one-function toggle for the button to use
-func ToggleHugePages() error {
-	if getHugePagesStatus() {
-		err := RevertHugePages()
-		if err != nil {
-			return err
-		}
-	} else {
-		err := SetHugePages()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// ToggleShMem Simple one-function toggle for the button to use
-func ToggleShMem() error {
-	if getShMemStatus() {
-		err := RevertShMem()
-		if err != nil {
-			return err
-		}
-	} else {
-		err := SetShMem()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// ToggleCompactionProactiveness Simple one-function toggle for the button to use
-func ToggleCompactionProactiveness() error {
-	if getCompactionProactivenessStatus() {
-		err := RevertCompactionProactiveness()
-		if err != nil {
-			return err
-		}
-	} else {
-		err := SetCompactionProactiveness()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// ToggleDefrag Simple one-function toggle for the button to use
-func ToggleDefrag() error {
-	if getDefragStatus() {
-		err := RevertDefrag()
-		if err != nil {
-			return err
-		}
-	} else {
-		err := SetDefrag()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// TogglePageLockUnfairness Simple one-function toggle for the button to use
-func TogglePageLockUnfairness() error {
-	if getPageLockUnfairnessStatus() {
-		err := RevertPageLockUnfairness()
-		if err != nil {
-			return err
-		}
-	} else {
-		err := SetPageLockUnfairness()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func SetHugePages() error {
-	CryoUtils.InfoLog.Println("Enabling hugepages...")
-	// Remove a file accidentally included in a beta for testing
-	_ = removeFile(NHPTestingFile)
-	err := setUnitValue("hugepages", RecommendedHugePages)
-	if err != nil {
+		CryoUtils.ErrorLog.Println("Unable to set", unit, "to", TweakList[unit].Recommended)
 		return err
 	}
-	err = writeUnitFile("hugepages", RecommendedHugePages)
+	err = writeUnitFile(unit, TweakList[unit].Recommended)
 	if err != nil {
+		CryoUtils.ErrorLog.Println("Unable to write unit file for", unit)
 		return err
 	}
 	return nil
 }
 
-func RevertHugePages() error {
-	CryoUtils.InfoLog.Println("Disabling hugepages...")
-	err := setUnitValue("hugepages", DefaultHugePages)
+func RevertTweak(unit string) error {
+	CryoUtils.InfoLog.Println("Disabling", unit, "...")
+	err := setUnitValue(unit, TweakList[unit].Default)
 	if err != nil {
+		CryoUtils.ErrorLog.Println("Unable to revert", unit, "to", TweakList[unit].Default)
 		return err
 	}
-	err = removeUnitFile("hugepages")
+	err = removeUnitFile(unit)
 	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func SetCompactionProactiveness() error {
-	CryoUtils.InfoLog.Println("Setting compaction_proactiveness...")
-	err := setUnitValue("compaction_proactiveness", RecommendedCompactionProactiveness)
-	if err != nil {
-		return err
-	}
-	err = writeUnitFile("compaction_proactiveness", RecommendedCompactionProactiveness)
-	if err != nil {
+		CryoUtils.ErrorLog.Println("Unable to remove unit file for", unit)
 		return err
 	}
 	return nil
 }
 
-func RevertCompactionProactiveness() error {
-	CryoUtils.InfoLog.Println("Disabling compaction_proactiveness...")
-	err := setUnitValue("compaction_proactiveness", DefaultCompactionProactiveness)
-	if err != nil {
-		return err
+func ToggleTweak(unit string) error {
+	if isTweakEnabled(unit) {
+		return RevertTweak(unit)
 	}
-	err = removeUnitFile("compaction_proactiveness")
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func SetPageLockUnfairness() error {
-	CryoUtils.InfoLog.Println("Enabling page_lock_unfairness...")
-	err := setUnitValue("page_lock_unfairness", RecommendedPageLockUnfairness)
-	if err != nil {
-		return err
-	}
-	err = writeUnitFile("page_lock_unfairness", RecommendedPageLockUnfairness)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func RevertPageLockUnfairness() error {
-	CryoUtils.InfoLog.Println("Disabling page_lock_unfairness...")
-	err := setUnitValue("page_lock_unfairness", DefaultPageLockUnfairness)
-	if err != nil {
-		return err
-	}
-	err = removeUnitFile("page_lock_unfairness")
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func SetShMem() error {
-	CryoUtils.InfoLog.Println("Enabling shmem_enabled...")
-	err := setUnitValue("shmem_enabled", RecommendedShMem)
-	if err != nil {
-		return err
-	}
-	err = writeUnitFile("shmem_enabled", RecommendedShMem)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func RevertShMem() error {
-	CryoUtils.InfoLog.Println("Disabling shmem_enabled...")
-	err := setUnitValue("shmem_enabled", DefaultShMem)
-	if err != nil {
-		return err
-	}
-	err = removeUnitFile("shmem_enabled")
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func SetDefrag() error {
-	CryoUtils.InfoLog.Println("Enabling shmem_enabled...")
-	err := setUnitValue("defrag", RecommendedHugePageDefrag)
-	if err != nil {
-		return err
-	}
-	err = writeUnitFile("defrag", RecommendedHugePageDefrag)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func RevertDefrag() error {
-	CryoUtils.InfoLog.Println("Disabling shmem_enabled...")
-	err := setUnitValue("defrag", DefaultHugePageDefrag)
-	if err != nil {
-		return err
-	}
-	err = removeUnitFile("defrag")
-	if err != nil {
-		return err
-	}
-	return nil
+	return EnableTweak(unit)
 }

--- a/internal/handler_swap.go
+++ b/internal/handler_swap.go
@@ -125,7 +125,7 @@ func ChangeSwappiness(value string) error {
 		return err
 	}
 
-	if value == DefaultSwappiness {
+	if value == TweakList["swappiness"].Default {
 		CryoUtils.InfoLog.Println("Removing swappiness unit to revert to default behavior...")
 		err = removeUnitFile("swappiness")
 		if err != nil {

--- a/internal/ui_tab.go
+++ b/internal/ui_tab.go
@@ -1,13 +1,14 @@
 package internal
 
 import (
+	"strconv"
+	"strings"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/widget"
-	"strconv"
-	"strings"
 )
 
 // Home tab for "recommended" and "default" buttons
@@ -34,11 +35,11 @@ func (app *Config) homeTab() *fyne.Container {
 
 	actionText := widget.NewLabel(
 		"Swap: " + chosenSize + "GB\n" +
-			"Swappiness: " + RecommendedSwappiness + "\n" +
+			"Swappiness: " + TweakList["swappiness"].Recommended + "\n" +
 			"HugePages: Enabled\n" +
-			"Compaction Proactivenes: " + RecommendedCompactionProactiveness + "\n" +
+			"Compaction Proactivenes: " + TweakList["compaction_proactiveness"].Recommended + "\n" +
 			"HugePage Defragmentation: Disabled\n" +
-			"Page Lock Unfairness: " + RecommendedPageLockUnfairness + "\n" +
+			"Page Lock Unfairness: " + TweakList["page_lock_unfairness"].Recommended + "\n" +
 			"Shared Memory in Huge Pages: Enabled")
 
 	recommendedButton := widget.NewButton("Recommended", func() {
@@ -184,7 +185,7 @@ func (app *Config) memoryTab() *fyne.Container {
 
 	CryoUtils.HugePagesButton = widget.NewButton("Enable HugePages", func() {
 		renewSudoAuth()
-		err := ToggleHugePages()
+		err := ToggleTweak("hugepages")
 		if err != nil {
 			presentErrorInUI(err, CryoUtils.MainWindow)
 		}
@@ -193,7 +194,7 @@ func (app *Config) memoryTab() *fyne.Container {
 
 	CryoUtils.ShMemButton = widget.NewButton("Enable Shared Memory in THP", func() {
 		renewSudoAuth()
-		err := ToggleShMem()
+		err := ToggleTweak("shmem")
 		if err != nil {
 			presentErrorInUI(err, CryoUtils.MainWindow)
 		}
@@ -202,7 +203,7 @@ func (app *Config) memoryTab() *fyne.Container {
 
 	CryoUtils.CompactionProactivenessButton = widget.NewButton("Set Compaction Proactiveness", func() {
 		renewSudoAuth()
-		err := ToggleCompactionProactiveness()
+		err := ToggleTweak("compaction_proactiveness")
 		if err != nil {
 			presentErrorInUI(err, CryoUtils.MainWindow)
 		}
@@ -211,7 +212,7 @@ func (app *Config) memoryTab() *fyne.Container {
 
 	CryoUtils.DefragButton = widget.NewButton("Disable Huge Page Defragmentation", func() {
 		renewSudoAuth()
-		err := ToggleDefrag()
+		err := ToggleTweak("defrag")
 		if err != nil {
 			presentErrorInUI(err, CryoUtils.MainWindow)
 		}
@@ -220,7 +221,7 @@ func (app *Config) memoryTab() *fyne.Container {
 
 	CryoUtils.PageLockUnfairnessButton = widget.NewButton("Set Page Lock Unfairness", func() {
 		renewSudoAuth()
-		err := TogglePageLockUnfairness()
+		err := ToggleTweak("page_lock_unfairness")
 		if err != nil {
 			presentErrorInUI(err, CryoUtils.MainWindow)
 		}

--- a/internal/ui_util.go
+++ b/internal/ui_util.go
@@ -211,7 +211,7 @@ func (app *Config) refreshSwappinessContent() {
 	} else {
 		swappinessStr := fmt.Sprintf("Current Swappiness: %d", swappiness)
 		app.SwappinessText.Text = swappinessStr
-		if strconv.Itoa(swappiness) == RecommendedSwappiness {
+		if strconv.Itoa(swappiness) == TweakList["swappiness"].Recommended {
 			app.SwappinessText.Color = Green
 		} else {
 			app.SwappinessText.Color = Red
@@ -223,7 +223,7 @@ func (app *Config) refreshSwappinessContent() {
 
 func (app *Config) refreshHugePagesContent() {
 	app.InfoLog.Println("Refreshing HugePages data...")
-	if getHugePagesStatus() {
+	if isTweakEnabled("hugepages") {
 		app.HugePagesButton.Text = "Disable HugePages"
 		app.HugePagesText.Color = Green
 	} else {
@@ -236,7 +236,7 @@ func (app *Config) refreshHugePagesContent() {
 
 func (app *Config) refreshShMemContent() {
 	app.InfoLog.Println("Refreshing shmem data...")
-	if getShMemStatus() {
+	if isTweakEnabled("shmem_enabled") {
 		app.ShMemButton.Text = "Disable Shared Memory in THP"
 		app.ShMemText.Color = Green
 	} else {
@@ -250,7 +250,7 @@ func (app *Config) refreshShMemContent() {
 
 func (app *Config) refreshCompactionProactivenessContent() {
 	app.InfoLog.Println("Refreshing compaction proactiveness data...")
-	if getCompactionProactivenessStatus() {
+	if isTweakEnabled("compaction_proactiveness") {
 		app.CompactionProactivenessButton.Text = "Revert Compaction Proactiveness"
 		app.CompactionProactivenessText.Color = Green
 	} else {
@@ -263,7 +263,7 @@ func (app *Config) refreshCompactionProactivenessContent() {
 
 func (app *Config) refreshDefragContent() {
 	app.InfoLog.Println("Refreshing defragmentation data...")
-	if getDefragStatus() {
+	if isTweakEnabled("defrag") {
 		app.DefragButton.Text = "Enable Huge Page Defragmentation"
 		app.DefragText.Color = Green
 	} else {
@@ -276,7 +276,7 @@ func (app *Config) refreshDefragContent() {
 
 func (app *Config) refreshPageLockUnfairnessContent() {
 	app.InfoLog.Println("Refreshing page lock unfairness data...")
-	if getPageLockUnfairnessStatus() {
+	if isTweakEnabled("page_lock_unfairness") {
 		app.PageLockUnfairnessButton.Text = "Revert Page Lock Unfairness"
 		app.PageLockUnfairnessText.Color = Green
 	} else {

--- a/internal/util.go
+++ b/internal/util.go
@@ -225,9 +225,9 @@ func removeElementFromStringSlice(str string, slice []string) []string {
 
 func getUnitStatus(param string) (string, error) {
 	var output string
-	cmd, err := exec.Command("sudo", "cat", UnitMatrix[param]).Output()
+	cmd, err := exec.Command("sudo", "cat", TweakList[param].Location).Output()
 	if err != nil {
-		CryoUtils.ErrorLog.Println(err)
+		CryoUtils.ErrorLog.Println("Unable to get status of", param, ":", err)
 		return "nil", err
 	}
 	// This is just to get the actual value in units which present as a list.
@@ -248,7 +248,7 @@ func getUnitStatus(param string) (string, error) {
 func writeUnitFile(param string, value string) error {
 	path := filepath.Join(TmpFilesRoot, param+".conf")
 	CryoUtils.InfoLog.Println("Writing", value, "to", path, "to preserve", param, "setting...")
-	contents := strings.ReplaceAll(TemplateUnitFile, "PARAM", UnitMatrix[param])
+	contents := strings.ReplaceAll(TemplateUnitFile, "PARAM", TweakList[param].Location)
 	contents = strings.ReplaceAll(contents, "VALUE", value)
 	err := writeFile(path, contents)
 	if err != nil {
@@ -274,7 +274,7 @@ func setUnitValue(param string, value string) error {
 	// This mess is the only way I could find to push directly to unit files, without requiring
 	// a sudo password on installation to change capabilities.
 	echoCmd := exec.Command("echo", value)
-	teeCmd := exec.Command("sudo", "tee", UnitMatrix[param])
+	teeCmd := exec.Command("sudo", "tee", TweakList[param].Location)
 	reader, writer := io.Pipe()
 	var buf bytes.Buffer
 	echoCmd.Stdout = writer

--- a/internal/util.go
+++ b/internal/util.go
@@ -224,8 +224,15 @@ func removeElementFromStringSlice(str string, slice []string) []string {
 }
 
 func getUnitStatus(param string) (string, error) {
+	tweak, ok := TweakList[param]
+	// If the tweak isn't in the list, return an error. If you make a typo, this will catch it.
+	if !ok {
+		CryoUtils.ErrorLog.Println("Tweak not in list:", param)
+		return "nil", fmt.Errorf("Tweak not in list")
+	}
+
 	var output string
-	cmd, err := exec.Command("sudo", "cat", TweakList[param].Location).Output()
+	cmd, err := exec.Command("sudo", "cat", tweak.Location).Output()
 	if err != nil {
 		CryoUtils.ErrorLog.Println("Unable to get status of", param, ":", err)
 		return "nil", err


### PR DESCRIPTION
This pull request refactors the get, set, revert, and toggle methods in the memory handler, replacing separate functions with generic ones that can handle multiple jobs. This reduces lines of code, improves readability, and makes it easier to add tweaks in the future. Feedback is welcome, I believe it can be refactored further.