### PR TITLE
Safe validations for optimal usage

### DIFF
--- a/cmd/cryoutilities/main.go
+++ b/cmd/cryoutilities/main.go
@@ -13,10 +13,10 @@ import (
 )
 
 func main() {
+	// Create the install directory if it doesn't exist
+	os.MkdirAll(internal.InstallDirectory, 0755)
 	// Delete old log file
 	os.Remove(internal.LogFilePath)
-	// Create the Install Directory if it doesn't exist
-	os.MkdirAll(internal.InstallDirectory, 0755)
 	// Create a log file
 	logFile, err := os.OpenFile(internal.LogFilePath, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {

--- a/cmd/cryoutilities/main.go
+++ b/cmd/cryoutilities/main.go
@@ -15,6 +15,8 @@ import (
 func main() {
 	// Delete old log file
 	os.Remove(internal.LogFilePath)
+	// Create the Install Directory if it doesn't exist
+	os.MkdirAll(internal.InstallDirectory, 0755)
 	// Create a log file
 	logFile, err := os.OpenFile(internal.LogFilePath, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {

--- a/internal/config.go
+++ b/internal/config.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"image/color"
+	"os"
 	"path/filepath"
 )
 
@@ -9,7 +10,7 @@ import (
 var CurrentVersionNumber = "2.0.1"
 
 // InstallDirectory Location the program is installed.
-var InstallDirectory = "/home/deck/.cryo_utilities"
+var InstallDirectory = os.Getenv("HOME") + "/.cryo_utilities"
 
 // LogFilePath Location of the log file
 var LogFilePath = filepath.Join(InstallDirectory, "cryoutilities.log")


### PR DESCRIPTION
# Safe validations for optimal usage

This PR aims to provide small optimizations related to the first actions taken on the steam-deck-utilities.

First, by ensuring install directory exists before running the GUI directly.
Second, by replacing `/home/deck` by `os.Getenv("HOME")`, in order to prevent panics in custom installations.