### PR TITLE
Adding GPL v3 header to source files.

### DIFF
--- a/cmd/cryoutilities/main.go
+++ b/cmd/cryoutilities/main.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/cmd/cryoutilities/main.go
+++ b/cmd/cryoutilities/main.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package main
 
 import (

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 import (

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/handler_cli.go
+++ b/internal/handler_cli.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 import (

--- a/internal/handler_cli.go
+++ b/internal/handler_cli.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/handler_game_data.go
+++ b/internal/handler_game_data.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 import (

--- a/internal/handler_game_data.go
+++ b/internal/handler_game_data.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/handler_library.go
+++ b/internal/handler_library.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 import (

--- a/internal/handler_library.go
+++ b/internal/handler_library.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/handler_memory.go
+++ b/internal/handler_memory.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/handler_memory.go
+++ b/internal/handler_memory.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 func getHugePagesStatus() bool {

--- a/internal/handler_steam_api.go
+++ b/internal/handler_steam_api.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 import (

--- a/internal/handler_steam_api.go
+++ b/internal/handler_steam_api.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/handler_swap.go
+++ b/internal/handler_swap.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 import (

--- a/internal/handler_swap.go
+++ b/internal/handler_swap.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/ui_authentication.go
+++ b/internal/ui_authentication.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 import (

--- a/internal/ui_authentication.go
+++ b/internal/ui_authentication.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/ui_base.go
+++ b/internal/ui_base.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 import (

--- a/internal/ui_base.go
+++ b/internal/ui_base.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/ui_tab.go
+++ b/internal/ui_tab.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 import (

--- a/internal/ui_tab.go
+++ b/internal/ui_tab.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/ui_util.go
+++ b/internal/ui_util.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 import (

--- a/internal/ui_util.go
+++ b/internal/ui_util.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/ui_window.go
+++ b/internal/ui_window.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 import (

--- a/internal/ui_window.go
+++ b/internal/ui_window.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/util.go
+++ b/internal/util.go
@@ -1,3 +1,19 @@
+// Steam Deck Utilities
+// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 import (

--- a/internal/util.go
+++ b/internal/util.go
@@ -1,5 +1,5 @@
-// Steam Deck Utilities
-// Copyright (C) 2023 CryoByte33 and contributors to the Steam Deck Utilities project
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Issue: https://github.com/CryoByte33/steam-deck-utilities/issues/89

This PR introduces the GPL v3 header to all source files. This is aligned to [recommendations from GNU](https://www.gnu.org/licenses/gpl-howto.en.html) to ensure that users of this software are aware of the license while viewing any source files in isolation. 

Since there is no CLA for the project in place, I have attributed copyright to "CryoByte33 and contributors". 