### PR TITLE
Automatically sets FYNE_SCALE depeding on default monitor

### DIFF
--- a/internal/ui_base.go
+++ b/internal/ui_base.go
@@ -13,6 +13,8 @@ import (
 
 func InitUI() {
 	// Create a Fyne application
+	screenSizer := NewScreenSizer()
+	screenSizer.UpdateScaleForActiveMonitor()
 	fyneApp := app.NewWithID("io.cryobyte.cryoutilities")
 	CryoUtils.App = fyneApp
 	CryoUtils.App.SetIcon(ResourceIconPng)

--- a/internal/ui_screen.go
+++ b/internal/ui_screen.go
@@ -13,7 +13,6 @@ import (
 const (
 	smallScreen  = 1280
 	mediumScreen = 1980
-	hugeScreen   = 2680
 )
 
 const (

--- a/internal/ui_screen.go
+++ b/internal/ui_screen.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	smallScreen  = 1280
-	mediumScreen = 1980
+	mediumScreen = 1920
 )
 
 const (

--- a/internal/ui_screen.go
+++ b/internal/ui_screen.go
@@ -1,0 +1,74 @@
+package internal
+
+/*
+#cgo LDFLAGS: -lX11
+#include <X11/Xlib.h>
+*/
+import "C"
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	smallScreen  = 1280
+	mediumScreen = 1980
+	hugeScreen   = 2680
+)
+
+const (
+	defaultSteamDeckScreenWidth  = 1280
+	defaultSteamDeckScreenHeight = 800
+)
+
+const scaleEnvKey = "FYNE_SCALE"
+const defaultScreenName = ":0"
+
+type ScreenSizer struct {
+	screen screen
+}
+
+type screen struct {
+	name          string
+	width, height int
+}
+
+func NewScreenSizer() *ScreenSizer {
+	return &ScreenSizer{screen: getDefaultScreen()}
+}
+
+func getDefaultScreen() screen {
+	display := C.XOpenDisplay(nil)
+	if display == nil {
+		return screen{name: defaultScreenName, width: defaultSteamDeckScreenWidth, height: defaultSteamDeckScreenHeight}
+	}
+	defer C.XCloseDisplay(display)
+
+	displayScreen := C.XDefaultScreenOfDisplay(display)
+	displayScreenName := C.GoString(C.XDisplayString(display))
+	width := int(C.XWidthOfScreen(displayScreen))
+	height := int(C.XHeightOfScreen(displayScreen))
+	if width == 0 || height == 0 {
+		return screen{name: defaultScreenName, width: defaultSteamDeckScreenWidth, height: defaultSteamDeckScreenHeight}
+	}
+	return screen{displayScreenName, width, height}
+}
+
+func (s ScreenSizer) UpdateScaleForActiveMonitor() {
+	defaultScreen := getDefaultScreen()
+
+	if defaultScreen.width <= smallScreen {
+		s.setScale(0.25)
+	} else if defaultScreen.width > smallScreen && defaultScreen.width <= mediumScreen {
+		s.setScale(1)
+	} else if defaultScreen.width > mediumScreen {
+		s.setScale(2)
+	}
+}
+
+func (s ScreenSizer) setScale(f float32) {
+	err := os.Setenv(scaleEnvKey, fmt.Sprintf("%f", f))
+	if err != nil {
+		CryoUtils.ErrorLog.Println(err)
+	}
+}

--- a/internal/ui_screen.go
+++ b/internal/ui_screen.go
@@ -1,3 +1,19 @@
+// CryoUtilities
+// Copyright (C) 2023 CryoByte33 and contributors to the CryoUtilities project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package internal
 
 /*


### PR DESCRIPTION
Uses infamous X11/Xlib.h. Based on breaking points changes scale of app. No need for setting FYNE_SCALE trough launcher.

- Up to 1280 sets scale to 0.25
- Up to 1920 sets scale to 1
- Above 1920 sets scale to 2 