### PR TITLE
Swapfile emergency recovery and improvements

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 // CurrentVersionNumber Version number to build with, Fyne can't support build flags just yet.
-var CurrentVersionNumber = "2.1.2"
+var CurrentVersionNumber = "2.1.3"
 
 // Get home Directory
 var HomeDirectory, _ = os.UserHomeDir()
@@ -36,6 +36,7 @@ var RecommendedVRAM = 4096
 // Default Settings //
 //////////////////////
 
+var DefaultSwapFileLocation = "/home/swapfile"
 var DefaultSwapSize = 1
 var DefaultSwapSizeBytes = int64(DefaultSwapSize * GigabyteMultiplier)
 var DefaultSwappiness = "100"

--- a/internal/handler_swap.go
+++ b/internal/handler_swap.go
@@ -36,6 +36,10 @@ func getSwapFileLocation() (string, error) {
 		}
 	}
 
+	if doesFileExist(DefaultSwapFileLocation) {
+		return DefaultSwapFileLocation, nil
+	}
+
 	return "", fmt.Errorf("no swapfile found")
 }
 

--- a/internal/ui_util.go
+++ b/internal/ui_util.go
@@ -2,12 +2,12 @@ package internal
 
 import (
 	"fmt"
-	"path/filepath"
-	"sort"
-	"strconv"
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/widget"
+	"path/filepath"
+	"sort"
+	"strconv"
 )
 
 type GameStatus struct {
@@ -18,7 +18,7 @@ type GameStatus struct {
 // Show an error message over the main window.
 func presentErrorInUI(err error, win fyne.Window) {
 	CryoUtils.ErrorLog.Println(err)
-	dialog.ShowError(err, CryoUtils.MainWindow)
+	dialog.ShowError(err, win)
 }
 
 // Create a CheckGroup of game data to allow for selection.
@@ -196,7 +196,7 @@ func (app *Config) refreshSwapContent() {
 		humanSwapSize := swap / int64(GigabyteMultiplier)
 		swapStr := fmt.Sprintf("Current Swap Size: %dGB", humanSwapSize)
 		app.SwapText.Text = swapStr
-		if swap == RecommendedSwapSizeBytes {
+		if swap >= RecommendedSwapSizeBytes {
 			app.SwapText.Color = Green
 		} else {
 			app.SwapText.Color = Red
@@ -302,7 +302,7 @@ func (app *Config) refreshVRAMContent() {
 		app.VRAMText.Text = vramStr
 		app.VRAMText.Color = Gray
 	} else {
-		humanVRAMSize :=  getHumanVRAMSize(vram)
+		humanVRAMSize := getHumanVRAMSize(vram)
 		vramStr := fmt.Sprintf("Current VRAM: %s", humanVRAMSize)
 		app.VRAMText.Text = vramStr
 		if vram == RecommendedVRAM {

--- a/internal/util.go
+++ b/internal/util.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -114,6 +115,15 @@ func doesDirectoryExist(path string, directory string) bool {
 		}
 	}
 	return false
+}
+
+func doesFileExist(path string) bool {
+	_, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	} else {
+		return true
+	}
 }
 
 func isSubPath(parent string, sub string) bool {


### PR DESCRIPTION
- Implement fallback in case a swapfile is malformed
- Use green text for any swap file 16GB or greater
- Place error messages on correct window
- Bump patch version