### PR TITLE
Isolates all swap-related functionality into a separate struct

### DIFF
--- a/cmd/cryoutilities/main.go
+++ b/cmd/cryoutilities/main.go
@@ -24,6 +24,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/afero"
+
 	"cryoutilities/internal"
 
 	"github.com/cristalhq/acmd"
@@ -47,11 +49,15 @@ func main() {
 	// Print the current version as a test
 	internal.CryoUtils.InfoLog.Println("Current Version:", internal.CurrentVersionNumber)
 
+	// it is used to be replaced in unit-tests
+	appFs := afero.NewOsFs()
+
 	swap, err := internal.NewSwap(
 		internal.DefaultSwapSizeBytes,
 		internal.AvailableSwapSizes,
 		internal.OldSwappinessUnitFile,
 		internal.DefaultSwapFileLocation,
+		appFs,
 		internal.CryoUtils.InfoLog,
 	)
 	if err != nil {

--- a/cmd/cryoutilities/main.go
+++ b/cmd/cryoutilities/main.go
@@ -18,25 +18,26 @@ package main
 
 import (
 	"context"
-	"cryoutilities/internal"
 	"errors"
 	"log"
 	"os"
 	"strconv"
 	"strings"
 
+	"cryoutilities/internal"
+
 	"github.com/cristalhq/acmd"
 )
 
 func main() {
 	// Delete old log file
-	os.Remove(internal.LogFilePath)
+	func() { _ = os.Remove(internal.LogFilePath) }()
 	// Create a log file
 	logFile, err := os.OpenFile(internal.LogFilePath, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		log.Panic(err)
 	}
-	defer logFile.Close()
+	defer func() { _ = logFile.Close() }()
 	log.SetOutput(logFile)
 
 	// Create loggers
@@ -46,13 +47,24 @@ func main() {
 	// Print the current version as a test
 	internal.CryoUtils.InfoLog.Println("Current Version:", internal.CurrentVersionNumber)
 
+	swap, err := internal.NewSwap(
+		internal.DefaultSwapSizeBytes,
+		internal.AvailableSwapSizes,
+		internal.OldSwappinessUnitFile,
+		internal.DefaultSwapFileLocation,
+		internal.CryoUtils.InfoLog,
+	)
+	if err != nil {
+		log.Panicf("creating a swap struct: %v", err)
+	}
+
 	// Provide a command structure for parsing
 	cmds := []acmd.Command{
 		{
 			Name:        "gui",
 			Description: "Run in GUI mode",
 			ExecFunc: func(context.Context, []string) error {
-				internal.InitUI()
+				internal.InitUI(swap)
 				return nil
 			},
 		},
@@ -65,7 +77,7 @@ func main() {
 				if err != nil {
 					return err
 				}
-				err = internal.ChangeSwapSizeCLI(size, false)
+				err = internal.ChangeSwapSizeCLI(swap, size, false)
 				if err != nil {
 					return err
 				}
@@ -83,7 +95,7 @@ func main() {
 				if err != nil || swappinessInt < 0 || swappinessInt > 200 {
 					return errors.New("invalid swappiness value")
 				}
-				err = internal.ChangeSwappiness(swappiness)
+				err = swap.ChangeSwappiness(swappiness)
 				if err != nil {
 					return err
 				}
@@ -210,7 +222,7 @@ func main() {
 			Name:        "recommended",
 			Description: "Set all values to Cryo's recommendations.",
 			ExecFunc: func(context.Context, []string) error {
-				err := internal.UseRecommendedSettings()
+				err := internal.UseRecommendedSettings(swap)
 				if err != nil {
 					return err
 				}
@@ -221,7 +233,7 @@ func main() {
 			Name:        "stock",
 			Description: "Set all values to Valve defaults.",
 			ExecFunc: func(context.Context, []string) error {
-				err := internal.UseStockSettings()
+				err := internal.UseStockSettings(swap)
 				if err != nil {
 					return err
 				}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/jsummers/gobmp v0.0.0-20151104160322-e2ba15ffa76e // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/afero v1.9.4 // indirect
 	github.com/srwiley/oksvg v0.0.0-20220731023508-a61f04f16b76 // indirect
 	github.com/srwiley/rasterx v0.0.0-20210519020934-456a8d69b780 // indirect
 	github.com/stretchr/testify v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
+cloud.google.com/go v0.44.3/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
@@ -15,6 +16,7 @@ cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOY
 cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHObY=
 cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKPI=
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
+cloud.google.com/go v0.75.0/go.mod h1:VGuuCn7PG0dwsd5XPVm2Mm3wlh3EL55/79EKB6hlPTY=
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
 cloud.google.com/go v0.79.0/go.mod h1:3bzgcEeQlzbuEAYu4mrWhKqWjmpprinYgKJLgKHnbb8=
 cloud.google.com/go v0.81.0/go.mod h1:mk/AM35KwGk/Nm2YSeZbxXdrNK3KZOYHmLkOqC2V6E0=
@@ -36,6 +38,7 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
+cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 fyne.io/fyne/v2 v2.3.1 h1:2/dHeRXEpn/D4MyTHdK43g3/pxeLOi3FcdNJI+iphlM=
 fyne.io/fyne/v2 v2.3.1/go.mod h1:dl/M+f0r5lJRhy+gdPbmYy97tbu3SWF/RF6/9KXMs+s=
@@ -168,12 +171,14 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20211219123610-ec9572f70e60/go.mod h1:cz9oNYuRUWGdHmLF2IodMLkAhcPtXeULvcBNagUrxTI=
 github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
@@ -253,7 +258,9 @@ github.com/otiai10/mint v1.4.0/go.mod h1:gifjb2MYOoULtKLqUAEILUG/9KONW6f7YsJ6vQL
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
+github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -272,6 +279,8 @@ github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
+github.com/spf13/afero v1.9.4 h1:Sd43wM1IWz/s1aVXdOBkjJvuP8UdyqioeE4AmM0QsBs=
+github.com/spf13/afero v1.9.4/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
@@ -323,7 +332,9 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -399,6 +410,7 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
@@ -467,12 +479,14 @@ golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -545,6 +559,7 @@ golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
@@ -617,7 +632,9 @@ google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20210108203827-ffc7fda8c3d7/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210222152913-aa3ee6e6a81c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,6 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-fyne.io/fyne/v2 v2.3.1-rc2 h1:jTDwPaUrbVKS5dWYMp2aZ32xG8WvmjLuN0vIgdp5YYU=
-fyne.io/fyne/v2 v2.3.1-rc2/go.mod h1:dl/M+f0r5lJRhy+gdPbmYy97tbu3SWF/RF6/9KXMs+s=
 fyne.io/fyne/v2 v2.3.1 h1:2/dHeRXEpn/D4MyTHdK43g3/pxeLOi3FcdNJI+iphlM=
 fyne.io/fyne/v2 v2.3.1/go.mod h1:dl/M+f0r5lJRhy+gdPbmYy97tbu3SWF/RF6/9KXMs+s=
 fyne.io/systray v1.10.1-0.20230207085535-4a244dbb9d03 h1:zb84y6X6lIi4Aeo8ehu6Qtu2fipBZ6Wzp41Ki/F4qdg=

--- a/internal/handler_swap.go
+++ b/internal/handler_swap.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -25,16 +26,66 @@ import (
 	"strings"
 )
 
+type logger interface {
+	Println(v ...any)
+}
+
+// NewSwap is a constructor for Swap.
+func NewSwap(
+	defaultSwapSizeBytes int64,
+	availableSwapSizes []string,
+	oldSwappinessUnitFile string,
+	defaultSwapFileLocation string,
+	loggerInfo logger,
+) (*Swap, error) {
+	if defaultSwapSizeBytes == 0 {
+		return nil, errors.New("defaultSwapSizeBytes is required")
+	}
+	if len(availableSwapSizes) == 0 {
+		return nil, errors.New("availableSwapSizes is required")
+	}
+	if oldSwappinessUnitFile == "" {
+		return nil, errors.New("oldSwappinessUnitFile is required")
+	}
+	if loggerInfo == nil {
+		return nil, errors.New("info logger is required")
+	}
+	if defaultSwapFileLocation == "" {
+		return nil, errors.New("default swap location is required")
+	}
+	swapFileLocation, err := getSwapFileLocation(defaultSwapFileLocation)
+	if err != nil {
+		return nil, fmt.Errorf("getting swapfile location: %w", err)
+	}
+
+	return &Swap{
+		defaultSwapSizeBytes:  defaultSwapSizeBytes,
+		availableSwapSizes:    availableSwapSizes,
+		oldSwappinessUnitFile: oldSwappinessUnitFile,
+		swapFileLocation:      swapFileLocation,
+		loggerInfo:            loggerInfo,
+	}, nil
+}
+
+// Swap decorates all functionality related to swap/swappiness changes.
+type Swap struct {
+	defaultSwapSizeBytes  int64
+	availableSwapSizes    []string
+	oldSwappinessUnitFile string
+	swapFileLocation      string
+	loggerInfo            logger
+}
+
 // Get swap file location from the system (/proc/swaps)
 // Sample output:
 // Filename				Type		Size	Used	Priority
 // /home/swapfile			file		8388604	0	-2
-func getSwapFileLocation() (string, error) {
+func getSwapFileLocation(defaultSwapFileLocation string) (string, error) {
 	file, err := os.Open("/proc/swaps")
 	if err != nil {
 		return "", err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	scanner := bufio.NewScanner(file)
 	// skip the first line (header)
@@ -52,57 +103,50 @@ func getSwapFileLocation() (string, error) {
 		}
 	}
 
-	if doesFileExist(DefaultSwapFileLocation) {
-		return DefaultSwapFileLocation, nil
+	if doesFileExist(defaultSwapFileLocation) {
+		return defaultSwapFileLocation, nil
 	}
 
 	return "", fmt.Errorf("no swapfile found")
 }
 
 // Get the current swap and swappiness values
-func getSwappinessValue() (int, error) {
+func (s *Swap) getSwappinessValue() (int, error) {
 	cmd, err := exec.Command("sysctl", "vm.swappiness").Output()
 	if err != nil {
 		return 100, fmt.Errorf("error getting current swappiness")
 	}
 	output := strings.Fields(string(cmd))
-	CryoUtils.InfoLog.Println("Found a swappiness of", output[2])
+	s.loggerInfo.Println("Found a swappiness of", output[2])
 	swappiness, _ := strconv.Atoi(output[2])
 
 	return swappiness, nil
 }
 
 // Get current swap file size, in bytes.
-func getSwapFileSize() (int64, error) {
-	location, err := getSwapFileLocation()
-	if err != nil {
-		return DefaultSwapSizeBytes, fmt.Errorf("error getting swapfile location: %v", err)
-	}
-
-	CryoUtils.SwapFileLocation = location
-
-	info, err := os.Stat(CryoUtils.SwapFileLocation)
+func (s *Swap) getSwapFileSize() (int64, error) {
+	info, err := os.Stat(s.swapFileLocation)
 	if err != nil {
 		// Don't crash the program, just report the default size
-		return DefaultSwapSizeBytes, fmt.Errorf("error getting current swap file size")
+		return s.defaultSwapSizeBytes, fmt.Errorf("error getting current swap file size")
 	}
-	CryoUtils.InfoLog.Println("Found a swap file with a size of", info.Size())
+	s.loggerInfo.Println("Found a swap file with a size of", info.Size())
 	return info.Size(), nil
 }
 
 // Get the available space for a swap file and return a slice of strings
-func getAvailableSwapSizes() ([]string, error) {
+func (s *Swap) getAvailableSwapSizes() ([]string, error) {
 	// Get the free space in /home
-	currentSwapSize, _ := getSwapFileSize()
+	currentSwapSize, _ := s.getSwapFileSize()
 	availableSpace, err := getFreeSpace("/home")
 	if err != nil {
-		return nil, fmt.Errorf("error getting available space in /home")
+		return nil, fmt.Errorf("error getting available space in /home: %w", err)
 	}
 
 	// Loop through the range of available sizes and create a list of viable options for the current Deck.
 	// This will always leave 1 as an available option, just in case.
 	validSizes := []string{"1 - Default"}
-	for _, size := range AvailableSwapSizes {
+	for _, size := range s.availableSwapSizes {
 		intSize, _ := strconv.Atoi(size)
 		byteSize := intSize * GigabyteMultiplier
 		if int64(byteSize+SpaceOverhead) < (availableSpace + currentSwapSize) {
@@ -115,70 +159,70 @@ func getAvailableSwapSizes() ([]string, error) {
 		}
 	}
 
-	CryoUtils.InfoLog.Println("Available Swap Sizes:", validSizes)
+	s.loggerInfo.Println("Available Swap Sizes:", validSizes)
 	return validSizes, nil
 }
 
 // Disable swapping completely
-func disableSwap() error {
-	CryoUtils.InfoLog.Println("Disabling swap temporarily...")
+func (s *Swap) disableSwap() error {
+	s.loggerInfo.Println("Disabling swap temporarily...")
 	_, err := exec.Command("sudo", "swapoff", "-a").Output()
 	if err != nil {
-		return fmt.Errorf("error disabling swap")
+		return fmt.Errorf("error disabling swap: %w", err)
 	}
 	return err
 }
 
 // Resize the swap file to the provided size, in GB.
-func resizeSwapFile(size int) error {
-	locationArg := fmt.Sprintf("of=%s", CryoUtils.SwapFileLocation)
+func (s *Swap) resizeSwapFile(size int) error {
+	locationArg := fmt.Sprintf("of=%s", s.swapFileLocation)
 	countArg := fmt.Sprintf("count=%d", size)
 
-	CryoUtils.InfoLog.Println("Resizing swap to", size, "GB...")
+	s.loggerInfo.Println("Resizing swap to", size, "GB...")
 	// Use dd to write zeroes, reevaluate using Go directly in the future
 	_, err := exec.Command("sudo", "dd", "if=/dev/zero", locationArg, "bs=1G", countArg, "status=progress").Output()
 	if err != nil {
-		return fmt.Errorf("error resizing %s", CryoUtils.SwapFileLocation)
+		return fmt.Errorf("error resizing %s: %w", s.swapFileLocation, err)
 	}
 	return nil
 }
 
 // Set swap permissions to a valid value.
-func setSwapPermissions() error {
-	CryoUtils.InfoLog.Println("Setting permissions on", CryoUtils.SwapFileLocation, "to 0600...")
-	_, err := exec.Command("sudo", "chmod", "600", CryoUtils.SwapFileLocation).Output()
+func (s *Swap) setSwapPermissions() error {
+	s.loggerInfo.Println("Setting permissions on", s.swapFileLocation, "to 0600...")
+	_, err := exec.Command("sudo", "chmod", "600", s.swapFileLocation).Output()
 	if err != nil {
-		return fmt.Errorf("error setting permissions on %s", CryoUtils.SwapFileLocation)
+		return fmt.Errorf("error setting permissions on %s: %w", s.swapFileLocation, err)
 	}
 	return nil
 }
 
 // Enable swapping on the newly resized file.
-func initNewSwapFile() error {
-	CryoUtils.InfoLog.Println("Enabling swap on", CryoUtils.SwapFileLocation, "...")
-	_, err := exec.Command("sudo", "mkswap", CryoUtils.SwapFileLocation).Output()
+func (s *Swap) initNewSwapFile() error {
+	s.loggerInfo.Println("Enabling swap on", s.swapFileLocation, "...")
+	_, err := exec.Command("sudo", "mkswap", s.swapFileLocation).Output()
 	if err != nil {
-		return fmt.Errorf("error creating swap on %s", CryoUtils.SwapFileLocation)
+		return fmt.Errorf("error creating swap on %s: %w", s.swapFileLocation, err)
 	}
-	_, err = exec.Command("sudo", "swapon", CryoUtils.SwapFileLocation).Output()
+	_, err = exec.Command("sudo", "swapon", s.swapFileLocation).Output()
 	if err != nil {
-		return fmt.Errorf("error enabling swap on %s", CryoUtils.SwapFileLocation)
+		return fmt.Errorf("error enabling swap on %s: %w", s.swapFileLocation, err)
 	}
 	return nil
 }
 
 // ChangeSwappiness Set swappiness to the provided integer.
-func ChangeSwappiness(value string) error {
-	CryoUtils.InfoLog.Println("Setting swappiness...")
+func (s *Swap) ChangeSwappiness(value string) error {
+	s.loggerInfo.Println("Setting swappiness...")
 	// Remove old swappiness file while we're at it
-	_ = removeFile(OldSwappinessUnitFile)
+	_ = removeFile(s.oldSwappinessUnitFile)
 	err := setUnitValue("swappiness", value)
 	if err != nil {
 		return err
 	}
 
 	if value == DefaultSwappiness {
-		CryoUtils.InfoLog.Println("Removing swappiness unit to revert to default behavior...")
+		s.loggerInfo.Println("Removing swappiness unit to revert to default behavior...")
 		err = removeUnitFile("swappiness")
 		if err != nil {
 			return err

--- a/internal/handler_swap_test.go
+++ b/internal/handler_swap_test.go
@@ -9,10 +9,8 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
-
-var testValidProcsFileContent = `Filename				Type		Size	Used	Priority
-/home/swapfile			file		8388604	0	-2`
 
 var _ logger = &testLogger{}
 
@@ -24,12 +22,65 @@ func (l *testLogger) Println(v ...any) {
 	l.entries = append(l.entries, v)
 }
 
-func Test_NewSwap(t *testing.T) {
+var _ execCommander = &testCommander{}
+
+type testCommander struct {
+	// map key is the name + " " + arg[0]
+	shouldReturn     map[string]testCommanderReturn
+	commandsExecuted []struct {
+		name string
+		args []string
+	}
+}
+
+type testCommanderReturn struct {
+	value string
+	err   error
+}
+
+func (c *testCommander) ExecAndOutput(name string, arg ...string) ([]byte, error) {
+	c.commandsExecuted = append(c.commandsExecuted, struct {
+		name string
+		args []string
+	}{name: name, args: arg})
+
+	searchBy := name
+	if len(arg) > 0 {
+		searchBy += " " + strings.Join(arg, " ")
+	}
+	shouldReturn, ok := c.shouldReturn[searchBy]
+	if !ok {
+		panic(fmt.Errorf("failed to find a result to return for %q", searchBy))
+	}
+
+	return []byte(shouldReturn.value), shouldReturn.err
+}
+
+type SwapTestSuite struct {
+	suite.Suite
+	validProcsFileContent string
+}
+
+func Test_SwapTestSuite(t *testing.T) {
+	s := new(SwapTestSuite)
+	s.validProcsFileContent = `Filename				Type		Size	Used	Priority
+/home/swapfile			file		8388604	0	-2`
+
+	suite.Run(t, s)
+}
+
+func (s *SwapTestSuite) getValidFS() afero.Fs {
 	validFS := afero.NewMemMapFs()
 	err := validFS.MkdirAll("/proc/", 0755)
-	require.NoError(t, err, "creating mem fs dir /proc/")
-	err = afero.WriteFile(validFS, "/proc/swaps", []byte(testValidProcsFileContent), 0444)
-	require.NoError(t, err, "writing mem fs file /proc/swaps")
+	require.NoError(s.T(), err, "creating mem fs dir /proc/")
+	err = afero.WriteFile(validFS, "/proc/swaps", []byte(s.validProcsFileContent), 0444)
+	require.NoError(s.T(), err, "writing mem fs file /proc/swaps")
+
+	return validFS
+}
+
+func (s *SwapTestSuite) Test_NewSwap() {
+	validFS := s.getValidFS()
 
 	tt := []struct {
 		name                    string
@@ -56,6 +107,7 @@ func Test_NewSwap(t *testing.T) {
 				oldSwappinessUnitFile: "/etc/sysctl.d/zzz-custom-swappiness.conf",
 				swapFileLocation:      "/home/swapfile",
 				fs:                    validFS,
+				execCommander:         realExecCommander{},
 				loggerInfo:            &testLogger{},
 			},
 			expectedError: nil,
@@ -122,11 +174,9 @@ func Test_NewSwap(t *testing.T) {
 			oldSwappinessUnitFile:   "/etc/sysctl.d/zzz-custom-swappiness.conf",
 			defaultSwapFileLocation: "/home/swapfile",
 			fs: func() afero.Fs {
-				fs := afero.NewMemMapFs()
-				err := fs.MkdirAll("/proc/", 0755)
-				require.NoError(t, err, "creating mem fs dir custom /proc/")
-				err = afero.WriteFile(fs, "/proc/swaps", []byte("wrong file"), 0444)
-				require.NoError(t, err, "writing mem fs file custom /proc/swaps")
+				fs := s.getValidFS()
+				err := afero.WriteFile(fs, "/proc/swaps", []byte("wrong file"), 0444)
+				require.NoError(s.T(), err, "writing mem fs file custom /proc/swaps")
 				return fs
 			}(),
 			loggerInfo:     &testLogger{},
@@ -147,7 +197,7 @@ func Test_NewSwap(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
+		s.T().Run(tc.name, func(t *testing.T) {
 			res, err := NewSwap(
 				tc.defaultSwapSizeBytes,
 				tc.availableSwapSizes,
@@ -163,7 +213,7 @@ func Test_NewSwap(t *testing.T) {
 	}
 }
 
-func Test_getSwapFileLocation(t *testing.T) {
+func (s *SwapTestSuite) Test_getSwapFileLocation() {
 	tt := []struct {
 		name                    string
 		fileContent             []byte
@@ -173,7 +223,7 @@ func Test_getSwapFileLocation(t *testing.T) {
 	}{
 		{
 			name:                    "happy path",
-			fileContent:             []byte(testValidProcsFileContent),
+			fileContent:             []byte(s.validProcsFileContent),
 			defaultSwapFileLocation: "/home/swapfile__default",
 			expectedResult:          "/home/swapfile", // comes from procs file
 			expectedError:           nil,
@@ -188,7 +238,7 @@ func Test_getSwapFileLocation(t *testing.T) {
 		{
 			name: "swapfile is a partition - error",
 			fileContent: func() []byte {
-				data := strings.Replace(testValidProcsFileContent, "/home/swapfile", "/dev/1", -1)
+				data := strings.Replace(s.validProcsFileContent, "/home/swapfile", "/dev/1", -1)
 				return []byte(data)
 			}(),
 			defaultSwapFileLocation: "/home/swapfile__default",
@@ -205,12 +255,13 @@ func Test_getSwapFileLocation(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			fs := afero.NewMemMapFs()
-			err := fs.MkdirAll("/proc/", 0755)
-			require.NoError(t, err, "creating mem fs dir /proc/")
-			if tc.fileContent != nil {
-				err = afero.WriteFile(fs, "/proc/swaps", tc.fileContent, 0444)
+		s.T().Run(tc.name, func(t *testing.T) {
+			fs := s.getValidFS()
+			if tc.fileContent == nil {
+				err := fs.Remove("/proc/swaps")
+				require.NoError(t, err, "removing from mem fs file /proc/swaps")
+			} else {
+				err := afero.WriteFile(fs, "/proc/swaps", tc.fileContent, 0444)
 				require.NoError(t, err, "writing mem fs file /proc/swaps")
 			}
 
@@ -220,4 +271,368 @@ func Test_getSwapFileLocation(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, res)
 		})
 	}
+}
+
+func (s *SwapTestSuite) Test_Swap_getSwappinessValue() {
+	tt := []struct {
+		name                      string
+		testCommanderShouldReturn map[string]testCommanderReturn
+		expectedResult            int
+		expectedError             error
+		expectedLogs              [][]any
+	}{
+		{
+			name: "happy path",
+			testCommanderShouldReturn: map[string]testCommanderReturn{
+				"sysctl vm.swappiness": {
+					value: "vm.swappiness = 10",
+					err:   nil,
+				},
+			},
+			expectedResult: 10,
+			expectedError:  nil,
+			expectedLogs:   [][]any{{"Found a swappiness of", "10"}},
+		},
+		{
+			name: "commander error - error",
+			testCommanderShouldReturn: map[string]testCommanderReturn{
+				"sysctl vm.swappiness": {
+					value: "",
+					err:   errors.New("commander error"),
+				},
+			},
+			expectedResult: 100, // default
+			expectedError:  errors.New("error getting current swappiness: commander error"),
+			expectedLogs:   nil,
+		},
+		{
+			name: "unexpected value from commander - error",
+			testCommanderShouldReturn: map[string]testCommanderReturn{
+				"sysctl vm.swappiness": {
+					value: "",
+					err:   nil,
+				},
+			},
+			expectedResult: 100, // default
+			expectedError:  errors.New("unexpected swappiness returned: \"\""),
+			expectedLogs:   nil,
+		},
+		{
+			name: "non-int swappiness value from commander - error",
+			testCommanderShouldReturn: map[string]testCommanderReturn{
+				"sysctl vm.swappiness": {
+					value: "vm.swappiness = ten",
+					err:   nil,
+				},
+			},
+			expectedResult: 100, // default
+			expectedError:  errors.New("converting swappiness of \"vm.swappiness = ten\": strconv.Atoi: parsing \"ten\": invalid syntax"),
+			expectedLogs:   nil,
+		},
+	}
+
+	for _, tc := range tt {
+		s.T().Run(tc.name, func(t *testing.T) {
+			fs := s.getValidFS()
+			lgr := &testLogger{}
+			swap, err := NewSwap(DefaultSwapSizeBytes, AvailableSwapSizes, OldSwappinessUnitFile, DefaultSwapFileLocation, fs, lgr)
+			require.NoError(t, err, "instantiating a new swap")
+			commander := &testCommander{
+				shouldReturn:     tc.testCommanderShouldReturn,
+				commandsExecuted: nil,
+			}
+			swap.execCommander = commander
+
+			res, err := swap.getSwappinessValue()
+
+			require.Equal(t, fmt.Sprintf("%v", tc.expectedError), fmt.Sprintf("%v", err))
+			assert.Equal(t, tc.expectedResult, res)
+			assert.Equal(t, tc.expectedLogs, lgr.entries)
+		})
+	}
+}
+
+func (s *SwapTestSuite) Test_Swap_getSwapFileSize() {
+	validSwapFileContent := "swap file content to have non-zero size"
+	tt := []struct {
+		name            string
+		swapfileContent []byte
+		expectedResult  int64
+		expectedError   error
+		expectedLogs    [][]any
+	}{
+		{
+			name:            "happy path",
+			swapfileContent: []byte(validSwapFileContent),
+			expectedResult:  int64(len(validSwapFileContent)),
+			expectedError:   nil,
+			expectedLogs:    [][]any{{"Found a swap file with a size of", int64(len(validSwapFileContent))}},
+		},
+		{
+			name:            "no swap file - error",
+			swapfileContent: nil,
+			expectedResult:  0,
+			expectedError:   errors.New("error getting current swap file size: open /home/swapfile: file does not exist"),
+			expectedLogs:    nil,
+		},
+	}
+
+	for _, tc := range tt {
+		s.T().Run(tc.name, func(t *testing.T) {
+			fs := s.getValidFS()
+			if tc.swapfileContent != nil {
+				err := afero.WriteFile(fs, "/home/swapfile", tc.swapfileContent, 0444)
+				require.NoError(t, err, "writing mem fs file /home/swapfile")
+			}
+			lgr := &testLogger{}
+			swap, err := NewSwap(DefaultSwapSizeBytes, AvailableSwapSizes, OldSwappinessUnitFile, DefaultSwapFileLocation, fs, lgr)
+			require.NoError(t, err, "instantiating a new swap")
+
+			res, err := swap.getSwapFileSize()
+
+			require.Equal(t, fmt.Sprintf("%v", tc.expectedError), fmt.Sprintf("%v", err))
+			if err == nil {
+				assert.Equal(t, tc.expectedResult, res)
+			}
+			assert.Equal(t, tc.expectedLogs, lgr.entries)
+		})
+	}
+}
+
+func (s *SwapTestSuite) Test_Swap_getAvailableSwapSizes() {
+	// TODO - now it depends on utilities and thus depends on real os; need to refactor before testing
+}
+
+func (s *SwapTestSuite) Test_Swap_disableSwap() {
+	tt := []struct {
+		name                      string
+		testCommanderShouldReturn map[string]testCommanderReturn
+		expectedError             error
+		expectedLogs              [][]any
+	}{
+		{
+			name: "happy path",
+			testCommanderShouldReturn: map[string]testCommanderReturn{
+				"sudo swapoff -a": {
+					value: "",
+					err:   nil,
+				},
+			},
+			expectedError: nil,
+			expectedLogs:  [][]any{{"Disabling swap temporarily..."}},
+		},
+		{
+			name: "error from commander - return error",
+			testCommanderShouldReturn: map[string]testCommanderReturn{
+				"sudo swapoff -a": {
+					value: "",
+					err:   errors.New("commander error"),
+				},
+			},
+			expectedError: errors.New("error disabling swap: commander error"),
+			expectedLogs:  [][]any{{"Disabling swap temporarily..."}},
+		},
+	}
+
+	for _, tc := range tt {
+		s.T().Run(tc.name, func(t *testing.T) {
+			fs := s.getValidFS()
+			lgr := &testLogger{}
+			swap, err := NewSwap(DefaultSwapSizeBytes, AvailableSwapSizes, OldSwappinessUnitFile, DefaultSwapFileLocation, fs, lgr)
+			require.NoError(t, err, "instantiating a new swap")
+			commander := &testCommander{
+				shouldReturn:     tc.testCommanderShouldReturn,
+				commandsExecuted: nil,
+			}
+			swap.execCommander = commander
+
+			err = swap.disableSwap()
+
+			require.Equal(t, fmt.Sprintf("%v", tc.expectedError), fmt.Sprintf("%v", err))
+			assert.Equal(t, tc.expectedLogs, lgr.entries)
+		})
+	}
+}
+
+func (s *SwapTestSuite) Test_Swap_resizeSwapFile() {
+	tt := []struct {
+		name                      string
+		size                      int
+		testCommanderShouldReturn map[string]testCommanderReturn
+		expectedError             error
+		expectedLogs              [][]any
+	}{
+		{
+			name: "happy path",
+			size: 16,
+			testCommanderShouldReturn: map[string]testCommanderReturn{
+				"sudo dd if=/dev/zero of=/home/swapfile bs=1G count=16 status=progress": {
+					value: "",
+					err:   nil,
+				},
+			},
+			expectedError: nil,
+			expectedLogs:  [][]any{{"Resizing swap to", 16, "GB..."}},
+		},
+		{
+			name: "commander error - return error",
+			size: 16,
+			testCommanderShouldReturn: map[string]testCommanderReturn{
+				"sudo dd if=/dev/zero of=/home/swapfile bs=1G count=16 status=progress": {
+					value: "",
+					err:   errors.New("commander error"),
+				},
+			},
+			expectedError: errors.New("error resizing /home/swapfile: commander error"),
+			expectedLogs:  [][]any{{"Resizing swap to", 16, "GB..."}},
+		},
+	}
+
+	for _, tc := range tt {
+		s.T().Run(tc.name, func(t *testing.T) {
+			fs := s.getValidFS()
+			lgr := &testLogger{}
+			swap, err := NewSwap(DefaultSwapSizeBytes, AvailableSwapSizes, OldSwappinessUnitFile, DefaultSwapFileLocation, fs, lgr)
+			require.NoError(t, err, "instantiating a new swap")
+			commander := &testCommander{
+				shouldReturn:     tc.testCommanderShouldReturn,
+				commandsExecuted: nil,
+			}
+			swap.execCommander = commander
+
+			err = swap.resizeSwapFile(tc.size)
+
+			require.Equal(t, fmt.Sprintf("%v", tc.expectedError), fmt.Sprintf("%v", err))
+			assert.Equal(t, tc.expectedLogs, lgr.entries)
+		})
+	}
+}
+
+func (s *SwapTestSuite) Test_Swap_setSwapPermissions() {
+	tt := []struct {
+		name                      string
+		testCommanderShouldReturn map[string]testCommanderReturn
+		expectedError             error
+		expectedLogs              [][]any
+	}{
+		{
+			name: "happy path",
+			testCommanderShouldReturn: map[string]testCommanderReturn{
+				"sudo chmod 600 /home/swapfile": {
+					value: "",
+					err:   nil,
+				},
+			},
+			expectedError: nil,
+			expectedLogs:  [][]any{{"Setting permissions on", "/home/swapfile", "to 0600..."}},
+		},
+		{
+			name: "commander error - return error",
+			testCommanderShouldReturn: map[string]testCommanderReturn{
+				"sudo chmod 600 /home/swapfile": {
+					value: "",
+					err:   errors.New("commander error"),
+				},
+			},
+			expectedError: errors.New("error setting permissions on /home/swapfile: commander error"),
+			expectedLogs:  [][]any{{"Setting permissions on", "/home/swapfile", "to 0600..."}},
+		},
+	}
+
+	for _, tc := range tt {
+		s.T().Run(tc.name, func(t *testing.T) {
+			fs := s.getValidFS()
+			lgr := &testLogger{}
+			swap, err := NewSwap(DefaultSwapSizeBytes, AvailableSwapSizes, OldSwappinessUnitFile, DefaultSwapFileLocation, fs, lgr)
+			require.NoError(t, err, "instantiating a new swap")
+			commander := &testCommander{
+				shouldReturn:     tc.testCommanderShouldReturn,
+				commandsExecuted: nil,
+			}
+			swap.execCommander = commander
+
+			err = swap.setSwapPermissions()
+
+			require.Equal(t, fmt.Sprintf("%v", tc.expectedError), fmt.Sprintf("%v", err))
+			assert.Equal(t, tc.expectedLogs, lgr.entries)
+		})
+	}
+}
+
+func (s *SwapTestSuite) Test_Swap_initNewSwapFile() {
+	tt := []struct {
+		name                      string
+		testCommanderShouldReturn map[string]testCommanderReturn
+		expectedError             error
+		expectedLogs              [][]any
+	}{
+		{
+			name: "happy path",
+			testCommanderShouldReturn: map[string]testCommanderReturn{
+				"sudo mkswap /home/swapfile": {
+					value: "",
+					err:   nil,
+				},
+				"sudo swapon /home/swapfile": {
+					value: "",
+					err:   nil,
+				},
+			},
+			expectedError: nil,
+			expectedLogs:  [][]any{{"Enabling swap on", "/home/swapfile", "..."}},
+		},
+		{
+			name: "mkswap error - return error",
+			testCommanderShouldReturn: map[string]testCommanderReturn{
+				"sudo mkswap /home/swapfile": {
+					value: "",
+					err:   errors.New("mkswap error"),
+				},
+				"sudo swapon /home/swapfile": {
+					value: "",
+					err:   nil,
+				},
+			},
+			expectedError: errors.New("error creating swap on /home/swapfile: mkswap error"),
+			expectedLogs:  [][]any{{"Enabling swap on", "/home/swapfile", "..."}},
+		},
+		{
+			name: "swapon error - return error",
+			testCommanderShouldReturn: map[string]testCommanderReturn{
+				"sudo mkswap /home/swapfile": {
+					value: "",
+					err:   nil,
+				},
+				"sudo swapon /home/swapfile": {
+					value: "",
+					err:   errors.New("swapon error"),
+				},
+			},
+			expectedError: errors.New("error enabling swap on /home/swapfile: swapon error"),
+			expectedLogs:  [][]any{{"Enabling swap on", "/home/swapfile", "..."}},
+		},
+	}
+
+	for _, tc := range tt {
+		s.T().Run(tc.name, func(t *testing.T) {
+			fs := s.getValidFS()
+			lgr := &testLogger{}
+			swap, err := NewSwap(DefaultSwapSizeBytes, AvailableSwapSizes, OldSwappinessUnitFile, DefaultSwapFileLocation, fs, lgr)
+			require.NoError(t, err, "instantiating a new swap")
+			commander := &testCommander{
+				shouldReturn:     tc.testCommanderShouldReturn,
+				commandsExecuted: nil,
+			}
+			swap.execCommander = commander
+
+			err = swap.initNewSwapFile()
+
+			require.Equal(t, fmt.Sprintf("%v", tc.expectedError), fmt.Sprintf("%v", err))
+			assert.Equal(t, tc.expectedLogs, lgr.entries)
+		})
+	}
+}
+
+func (s *SwapTestSuite) Test_Swap_ChangeSwappiness() {
+	// TODO - now it depends on utilities and thus depends on real os; need to refactor before testing
 }

--- a/internal/handler_swap_test.go
+++ b/internal/handler_swap_test.go
@@ -1,0 +1,223 @@
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testValidProcsFileContent = `Filename				Type		Size	Used	Priority
+/home/swapfile			file		8388604	0	-2`
+
+var _ logger = &testLogger{}
+
+type testLogger struct {
+	entries [][]any
+}
+
+func (l *testLogger) Println(v ...any) {
+	l.entries = append(l.entries, v)
+}
+
+func Test_NewSwap(t *testing.T) {
+	validFS := afero.NewMemMapFs()
+	err := validFS.MkdirAll("/proc/", 0755)
+	require.NoError(t, err, "creating mem fs dir /proc/")
+	err = afero.WriteFile(validFS, "/proc/swaps", []byte(testValidProcsFileContent), 0444)
+	require.NoError(t, err, "writing mem fs file /proc/swaps")
+
+	tt := []struct {
+		name                    string
+		defaultSwapSizeBytes    int64
+		availableSwapSizes      []string
+		oldSwappinessUnitFile   string
+		defaultSwapFileLocation string
+		fs                      afero.Fs
+		loggerInfo              logger
+		expectedResult          *Swap
+		expectedError           error
+	}{
+		{
+			name:                    "happy path",
+			defaultSwapSizeBytes:    1,
+			availableSwapSizes:      []string{"2", "4"},
+			oldSwappinessUnitFile:   "/etc/sysctl.d/zzz-custom-swappiness.conf",
+			defaultSwapFileLocation: "/home/swapfile",
+			fs:                      validFS,
+			loggerInfo:              &testLogger{},
+			expectedResult: &Swap{
+				defaultSwapSizeBytes:  1,
+				availableSwapSizes:    []string{"2", "4"},
+				oldSwappinessUnitFile: "/etc/sysctl.d/zzz-custom-swappiness.conf",
+				swapFileLocation:      "/home/swapfile",
+				fs:                    validFS,
+				loggerInfo:            &testLogger{},
+			},
+			expectedError: nil,
+		},
+		{
+			name:                    "zero default swap file size - error",
+			defaultSwapSizeBytes:    0,
+			availableSwapSizes:      []string{"2", "4"},
+			oldSwappinessUnitFile:   "/etc/sysctl.d/zzz-custom-swappiness.conf",
+			defaultSwapFileLocation: "/home/swapfile",
+			fs:                      validFS,
+			loggerInfo:              &testLogger{},
+			expectedResult:          nil,
+			expectedError:           errors.New("defaultSwapSizeBytes is required"),
+		},
+		{
+			name:                    "no available swap sizes - error",
+			defaultSwapSizeBytes:    1,
+			availableSwapSizes:      nil,
+			oldSwappinessUnitFile:   "/etc/sysctl.d/zzz-custom-swappiness.conf",
+			defaultSwapFileLocation: "/home/swapfile",
+			fs:                      validFS,
+			loggerInfo:              &testLogger{},
+			expectedResult:          nil,
+			expectedError:           errors.New("availableSwapSizes is required"),
+		},
+		{
+			name:                    "no oldSwappinessUnitFile - error",
+			defaultSwapSizeBytes:    1,
+			availableSwapSizes:      []string{"2", "4"},
+			oldSwappinessUnitFile:   "",
+			defaultSwapFileLocation: "/home/swapfile",
+			fs:                      validFS,
+			loggerInfo:              &testLogger{},
+			expectedResult:          nil,
+			expectedError:           errors.New("oldSwappinessUnitFile is required"),
+		},
+		{
+			name:                    "no defaultSwapFileLocation - error",
+			defaultSwapSizeBytes:    1,
+			availableSwapSizes:      []string{"2", "4"},
+			oldSwappinessUnitFile:   "/etc/sysctl.d/zzz-custom-swappiness.conf",
+			defaultSwapFileLocation: "",
+			fs:                      validFS,
+			loggerInfo:              &testLogger{},
+			expectedResult:          nil,
+			expectedError:           errors.New("default swap location is required"),
+		},
+		{
+			name:                    "no fs - error",
+			defaultSwapSizeBytes:    1,
+			availableSwapSizes:      []string{"2", "4"},
+			oldSwappinessUnitFile:   "/etc/sysctl.d/zzz-custom-swappiness.conf",
+			defaultSwapFileLocation: "/home/swapfile",
+			fs:                      nil,
+			loggerInfo:              &testLogger{},
+			expectedResult:          nil,
+			expectedError:           errors.New("fs is required"),
+		},
+		{
+			name:                    "wrong /proc/swaps - error",
+			defaultSwapSizeBytes:    1,
+			availableSwapSizes:      []string{"2", "4"},
+			oldSwappinessUnitFile:   "/etc/sysctl.d/zzz-custom-swappiness.conf",
+			defaultSwapFileLocation: "/home/swapfile",
+			fs: func() afero.Fs {
+				fs := afero.NewMemMapFs()
+				err := fs.MkdirAll("/proc/", 0755)
+				require.NoError(t, err, "creating mem fs dir custom /proc/")
+				err = afero.WriteFile(fs, "/proc/swaps", []byte("wrong file"), 0444)
+				require.NoError(t, err, "writing mem fs file custom /proc/swaps")
+				return fs
+			}(),
+			loggerInfo:     &testLogger{},
+			expectedResult: nil,
+			expectedError:  errors.New("getting swapfile location: no swapfile found in /proc/swaps"),
+		},
+		{
+			name:                    "no info logger - error",
+			defaultSwapSizeBytes:    1,
+			availableSwapSizes:      []string{"2", "4"},
+			oldSwappinessUnitFile:   "/etc/sysctl.d/zzz-custom-swappiness.conf",
+			defaultSwapFileLocation: "/home/swapfile",
+			fs:                      validFS,
+			loggerInfo:              nil,
+			expectedResult:          nil,
+			expectedError:           errors.New("info logger is required"),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := NewSwap(
+				tc.defaultSwapSizeBytes,
+				tc.availableSwapSizes,
+				tc.oldSwappinessUnitFile,
+				tc.defaultSwapFileLocation,
+				tc.fs,
+				tc.loggerInfo,
+			)
+
+			require.Equal(t, fmt.Sprintf("%v", tc.expectedError), fmt.Sprintf("%v", err))
+			assert.Equal(t, tc.expectedResult, res)
+		})
+	}
+}
+
+func Test_getSwapFileLocation(t *testing.T) {
+	tt := []struct {
+		name                    string
+		fileContent             []byte
+		defaultSwapFileLocation string
+		expectedResult          string
+		expectedError           error
+	}{
+		{
+			name:                    "happy path",
+			fileContent:             []byte(testValidProcsFileContent),
+			defaultSwapFileLocation: "/home/swapfile__default",
+			expectedResult:          "/home/swapfile", // comes from procs file
+			expectedError:           nil,
+		},
+		{
+			name:                    "no procs file - error",
+			fileContent:             nil,
+			defaultSwapFileLocation: "/home/swapfile__default",
+			expectedResult:          "",
+			expectedError:           errors.New("open /proc/swaps: file does not exist"),
+		},
+		{
+			name: "swapfile is a partition - error",
+			fileContent: func() []byte {
+				data := strings.Replace(testValidProcsFileContent, "/home/swapfile", "/dev/1", -1)
+				return []byte(data)
+			}(),
+			defaultSwapFileLocation: "/home/swapfile__default",
+			expectedResult:          "",
+			expectedError:           errors.New("no swapfile found in /proc/swaps"),
+		},
+		{
+			name:                    "no swapfile mentioned in /proc/swaps and default not exists - error",
+			fileContent:             []byte("some_data"),
+			defaultSwapFileLocation: "/home/swapfile__default",
+			expectedResult:          "",
+			expectedError:           errors.New("no swapfile found in /proc/swaps"),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			err := fs.MkdirAll("/proc/", 0755)
+			require.NoError(t, err, "creating mem fs dir /proc/")
+			if tc.fileContent != nil {
+				err = afero.WriteFile(fs, "/proc/swaps", tc.fileContent, 0444)
+				require.NoError(t, err, "writing mem fs file /proc/swaps")
+			}
+
+			res, err := getSwapFileLocation(fs, tc.defaultSwapFileLocation)
+
+			require.Equal(t, fmt.Sprintf("%v", tc.expectedError), fmt.Sprintf("%v", err))
+			assert.Equal(t, tc.expectedResult, res)
+		})
+	}
+}

--- a/internal/ui_base.go
+++ b/internal/ui_base.go
@@ -27,7 +27,7 @@ import (
 	"fyne.io/fyne/v2/widget"
 )
 
-func InitUI() {
+func InitUI(swap *Swap) {
 	// Create a Fyne application
 	fyneApp := app.NewWithID("io.cryobyte.cryoutilities")
 	CryoUtils.App = fyneApp
@@ -36,13 +36,13 @@ func InitUI() {
 	// Show and run the app
 	title := "CryoUtilities " + CurrentVersionNumber
 	CryoUtils.MainWindow = fyneApp.NewWindow(title)
-	CryoUtils.makeUI()
+	CryoUtils.makeUI(swap)
 	CryoUtils.MainWindow.CenterOnScreen()
 	CryoUtils.MainWindow.ShowAndRun()
 }
 
-func (app *Config) makeUI() {
-	app.authUI()
+func (app *Config) makeUI(swap *Swap) {
+	app.authUI(swap)
 
 	// Show a disclaimer that I'm not responsible for damage.
 	dialog.ShowConfirm("Disclaimer",
@@ -67,11 +67,11 @@ func (app *Config) makeUI() {
 	CryoUtils.MainWindow.SetMaster()
 }
 
-func (app *Config) mainUI() {
+func (app *Config) mainUI(swap *Swap) {
 	// Create heading section
 	tabs := container.NewAppTabs(
-		container.NewTabItemWithIcon("Home", theme.HomeIcon(), app.homeTab()),
-		container.NewTabItemWithIcon("Swap", theme.MailReplyAllIcon(), app.swapTab()),
+		container.NewTabItemWithIcon("Home", theme.HomeIcon(), app.homeTab(swap)),
+		container.NewTabItemWithIcon("Swap", theme.MailReplyAllIcon(), app.swapTab(swap)),
 		container.NewTabItemWithIcon("Memory", theme.ComputerIcon(), app.memoryTab()),
 		container.NewTabItemWithIcon("Storage", theme.StorageIcon(), app.storageTab()),
 		container.NewTabItemWithIcon("VRAM", theme.ViewFullScreenIcon(), app.vramTab()),
@@ -82,7 +82,7 @@ func (app *Config) mainUI() {
 	app.MainWindow.SetContent(finalContent)
 }
 
-func (app *Config) authUI() {
+func (app *Config) authUI(swap *Swap) {
 	// Refactor this, duplicated code.
 	passwordEntry := widget.NewPasswordEntry()
 	passwordEntry.OnSubmitted = func(s string) {
@@ -95,7 +95,7 @@ func (app *Config) authUI() {
 		} else {
 			CryoUtils.InfoLog.Println("Password valid, continuing...")
 			CryoUtils.UserPassword = s
-			app.mainUI()
+			app.mainUI(swap)
 		}
 	}
 	passwordButton := widget.NewButton("Submit", func() {
@@ -108,7 +108,7 @@ func (app *Config) authUI() {
 		} else {
 			CryoUtils.InfoLog.Println("Password valid, continuing...")
 			CryoUtils.UserPassword = passwordEntry.Text
-			app.mainUI()
+			app.mainUI(swap)
 		}
 	})
 	passwordVBox := container.NewVBox(passwordEntry, passwordButton)

--- a/internal/ui_util.go
+++ b/internal/ui_util.go
@@ -18,12 +18,13 @@ package internal
 
 import (
 	"fmt"
-	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/dialog"
-	"fyne.io/fyne/v2/widget"
 	"path/filepath"
 	"sort"
 	"strconv"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/widget"
 )
 
 type GameStatus struct {
@@ -200,19 +201,19 @@ func getDataToMoveUI(data DataToMove) (*widget.List, *widget.List, error) {
 	return leftList, rightList, nil
 }
 
-func (app *Config) refreshSwapContent() {
+func (app *Config) refreshSwapContent(swap *Swap) {
 	app.InfoLog.Println("Refreshing Swap data...")
-	swap, err := getSwapFileSize()
+	swapSize, err := swap.getSwapFileSize()
 	if err != nil {
 		CryoUtils.ErrorLog.Println(err)
 		swapStr := "Current Swap Size: Unknown"
 		app.SwapText.Text = swapStr
 		app.SwapText.Color = Gray
 	} else {
-		humanSwapSize := swap / int64(GigabyteMultiplier)
+		humanSwapSize := swapSize / int64(GigabyteMultiplier)
 		swapStr := fmt.Sprintf("Current Swap Size: %dGB", humanSwapSize)
 		app.SwapText.Text = swapStr
-		if swap >= RecommendedSwapSizeBytes {
+		if swapSize >= RecommendedSwapSizeBytes {
 			app.SwapText.Color = Green
 		} else {
 			app.SwapText.Color = Red
@@ -222,9 +223,9 @@ func (app *Config) refreshSwapContent() {
 	app.SwapText.Refresh()
 }
 
-func (app *Config) refreshSwappinessContent() {
+func (app *Config) refreshSwappinessContent(swap *Swap) {
 	app.InfoLog.Println("Refreshing Swappiness data...")
-	swappiness, err := getSwappinessValue()
+	swappiness, err := swap.getSwappinessValue()
 	if err != nil {
 		CryoUtils.ErrorLog.Println(err)
 		swappinessStr := "Current Swappiness: Unknown"
@@ -331,9 +332,9 @@ func (app *Config) refreshVRAMContent() {
 	app.VRAMText.Refresh()
 }
 
-func (app *Config) refreshAllContent() {
-	app.refreshSwapContent()
-	app.refreshSwappinessContent()
+func (app *Config) refreshAllContent(swap *Swap) {
+	app.refreshSwapContent(swap)
+	app.refreshSwappinessContent(swap)
 	app.refreshHugePagesContent()
 	app.refreshCompactionProactivenessContent()
 	app.refreshShMemContent()

--- a/internal/ui_window.go
+++ b/internal/ui_window.go
@@ -330,7 +330,7 @@ func cleanupDataWindow() {
 	w.Show()
 }
 
-func swapSizeWindow() {
+func swapSizeWindow(swap *Swap) {
 	// Create a new window
 	w := CryoUtils.App.NewWindow("Change Swap Size")
 
@@ -339,7 +339,7 @@ func swapSizeWindow() {
 	prompt.TextSize, prompt.TextStyle = 18, fyne.TextStyle{Bold: true}
 
 	// Determine maximum available space for a swap file and construct a list of available sizes based on it
-	availableSwapSizes, err := getAvailableSwapSizes()
+	availableSwapSizes, err := swap.getAvailableSwapSizes()
 	if err != nil {
 		presentErrorInUI(err, w)
 	}
@@ -362,7 +362,7 @@ func swapSizeWindow() {
 			w,
 		)
 		d.Show()
-		err = changeSwapSizeGUI(chosenSize)
+		err = changeSwapSizeGUI(swap, chosenSize)
 		if err != nil {
 			d.Hide()
 			presentErrorInUI(err, w)
@@ -374,7 +374,7 @@ func swapSizeWindow() {
 					"running 'ls -lash /home/swapfile' or 'swapon -s' in Konsole.",
 				CryoUtils.MainWindow,
 			)
-			CryoUtils.refreshSwapContent()
+			CryoUtils.refreshSwapContent(swap)
 			w.Close()
 		}
 	})
@@ -394,36 +394,36 @@ func swapSizeWindow() {
 }
 
 // Note: Having a separate function for this is hacky, but necessary for progress bar functionality
-func changeSwapSizeGUI(size int) error {
+func changeSwapSizeGUI(swap *Swap, size int) error {
 	// Disable swap temporarily
 	renewSudoAuth()
 	CryoUtils.InfoLog.Println("Disabling swap temporarily...")
-	err := disableSwap()
+	err := swap.disableSwap()
 	if err != nil {
 		return err
 	}
 	// Resize the file
 	renewSudoAuth()
-	err = resizeSwapFile(size)
+	err = swap.resizeSwapFile(size)
 	if err != nil {
 		return err
 	}
 	// Set permissions on file
 	renewSudoAuth()
-	err = setSwapPermissions()
+	err = swap.setSwapPermissions()
 	if err != nil {
 		return err
 	}
 	// Initialize new swap file
 	renewSudoAuth()
-	err = initNewSwapFile()
+	err = swap.initNewSwapFile()
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func swappinessWindow() {
+func swappinessWindow(swap *Swap) {
 	// Create a new window
 	w := CryoUtils.App.NewWindow("Change Swappiness")
 
@@ -440,7 +440,7 @@ func swappinessWindow() {
 	// Provide a button to submit the choice
 	swappinessChangeButton := widget.NewButton("Change Swappiness", func() {
 		renewSudoAuth()
-		err := ChangeSwappiness(chosenSwappiness)
+		err := swap.ChangeSwappiness(chosenSwappiness)
 		if err != nil {
 			presentErrorInUI(err, w)
 		} else {
@@ -449,7 +449,7 @@ func swappinessWindow() {
 				"Swappiness change completed!",
 				CryoUtils.MainWindow,
 			)
-			CryoUtils.refreshSwappinessContent()
+			CryoUtils.refreshSwappinessContent(swap)
 			w.Close()
 		}
 	})


### PR DESCRIPTION
The idea is to remove cross-dependencies (and do not depend on a config singleton), make the code more modular and testable. It would lead to more predictable behaviour in the future and simplify further maintenance.

For this, all dependencies are injected to struct on instantiating.
I had to add `spf13/afero` to mock `os.*` calls, e.g. `os.Open` -> `fs.Open`.
Also added `logger` interface to unit-test all logged messages by each method.
The last update is introducing `execCommander` interface. By default (in a real app) it is falling back to `exec.Command`, for tests we replace it with a mock to make sure the commands running by each method.

The majority of added lines are actually unit tests for handler_swap.