### PR TITLE
Detect if Fyne is already overriding scale

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	fyne.io/fyne/v2 v2.3.1
 	github.com/andygrunwald/vdf v1.1.0
 	github.com/cristalhq/acmd v0.11.0
+	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20221017161538-93cebf72946b
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/otiai10/copy v1.9.0
 	golang.org/x/sys v0.5.0
@@ -21,7 +22,6 @@ require (
 	github.com/fyne-io/glfw-js v0.0.0-20220120001248-ee7290d23504 // indirect
 	github.com/fyne-io/image v0.0.0-20220602074514-4956b0afb3d2 // indirect
 	github.com/go-gl/gl v0.0.0-20211210172815-726fda9656d6 // indirect
-	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20221017161538-93cebf72946b // indirect
 	github.com/go-text/typesetting v0.0.0-20221212183139-1eb938670a1f // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/goki/freetype v0.0.0-20220119013949-7a161fd3728c // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,6 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-fyne.io/fyne/v2 v2.3.1-rc2 h1:jTDwPaUrbVKS5dWYMp2aZ32xG8WvmjLuN0vIgdp5YYU=
-fyne.io/fyne/v2 v2.3.1-rc2/go.mod h1:dl/M+f0r5lJRhy+gdPbmYy97tbu3SWF/RF6/9KXMs+s=
 fyne.io/fyne/v2 v2.3.1 h1:2/dHeRXEpn/D4MyTHdK43g3/pxeLOi3FcdNJI+iphlM=
 fyne.io/fyne/v2 v2.3.1/go.mod h1:dl/M+f0r5lJRhy+gdPbmYy97tbu3SWF/RF6/9KXMs+s=
 fyne.io/systray v1.10.1-0.20230207085535-4a244dbb9d03 h1:zb84y6X6lIi4Aeo8ehu6Qtu2fipBZ6Wzp41Ki/F4qdg=


### PR DESCRIPTION
Fyne is using base DPI of 124, anything above gets scaled - Steam Deck has high DPI even though it is small resolution and Fyne want's to scale it 4,5x times - that's why setting 0,25 feels ok. What they are doing is taking that user preferred scale of 0,25 and multiplying it with 4,5 which equals 1,125.

The issue https://github.com/CryoByte33/steam-deck-utilities/issues/110 happens when your screen gets below 124 DPI (typically when you have 4K TV and you set lower resolution). Then my previous correction calculates 0,25 scale for 1280x800 resolution but Fyne calculates 0,49 (and everything below 1 rounded back to 1) so 0,25 * 1 equals 0,25 scale. So the app is 4x smaller then it should be. Therefore i am simulating the calculation of Fyne scale and try to detect if rounding was used. If it was i change the scale to 1 instead of 0,25 - This way we get 1 * 1 which equals 1 and that should be big enough for current DPI.