### PR TITLE
replace SplitList with Split

### DIFF
--- a/internal/util.go
+++ b/internal/util.go
@@ -143,8 +143,8 @@ func doesFileExist(path string) bool {
 }
 
 func isSubPath(parent string, sub string) bool {
-	subFolds := filepath.SplitList(sub)
-	for i, fold := range filepath.SplitList(parent) {
+	subFolds := strings.Split(sub, string(os.PathSeparator))
+	for i, fold := range strings.Split(parent, string(os.PathSeparator)) {
 		if subFolds[i] != fold {
 			return false
 		}


### PR DESCRIPTION
If my hunch is correct, this call to isSubPath currently does not work as intended. 
SplitList splits by the OS ListSeperator, which is usually `:`. I think that this call was supposed to be for paths and not a list of separated paths considering it was called to parse through the paths in the vdf files in `getDataToMove`. I'm adding what I think was the intended functionality of this code, which is splitting it by the path separator.